### PR TITLE
Add detailed documentation for each example

### DIFF
--- a/callmebot_whatsapp_example/README.md
+++ b/callmebot_whatsapp_example/README.md
@@ -1,0 +1,30 @@
+# 📱 CallMeBot WhatsApp Example
+
+This folder demonstrates how to send WhatsApp messages using the free [CallMeBot](https://www.callmebot.com/) API. It includes two scripts:
+
+- `whatsapp_sender.py` – a helper class that sends messages through the CallMeBot API.
+- `webhook_server.py` – a Flask application that exposes webhook endpoints and triggers WhatsApp notifications.
+
+The example is designed for classroom use so students can experiment with WhatsApp automation without needing a Twilio WhatsApp account.
+
+## How It Works
+1. `whatsapp_sender.py` loads your credentials from `.env` and provides methods to send plain, emoji, or formatted messages.
+2. `webhook_server.py` receives POST requests at `/webhook/*` and uses `WhatsAppSender` to deliver the messages.
+3. You can run the server locally and expose it with ngrok for testing.
+
+## Environment Variables
+Create a `.env` file based on `env_example.txt` and set the following values:
+
+| Variable | Description |
+|----------|-------------|
+| `WHATSAPP_PHONE_NUMBER` | Your WhatsApp number (country code, no `+`). |
+| `CALLMEBOT_API_KEY` | API key obtained by messaging CallMeBot. |
+| `WEBHOOK_SECRET` | Optional secret used to verify incoming webhook signatures. |
+
+## Running the Demo
+```bash
+cd callmebot_whatsapp_example
+pip install -r requirements.txt
+python webhook_server.py
+```
+Visit `http://localhost:5000/webhook/test` to send a test message. Use `ngrok http 5000` if you want to receive webhooks from external services.

--- a/car_service_example/README.md
+++ b/car_service_example/README.md
@@ -1,8 +1,31 @@
 # 🚗 Car Service Reminder
 
-This script collects customer contact information and a service date. It sends an email confirmation and an SMS reminder using Twilio.
+This example simulates an auto shop that collects customer contact details and a service date. It sends an email confirmation immediately and schedules an SMS reminder before the appointment.
 
-## Steps
-1. Copy `env_example.txt` to `.env` and fill in credentials.
-2. Install dependencies with `pip install -r requirements.txt`.
-3. Run `python service_reminder.py` and follow the prompts.
+## How It Works
+1. The script prompts for the customer's phone number, email, and desired service date.
+2. An email confirmation is sent using the SMTP settings from your `.env` file.
+3. A Twilio SMS reminder is scheduled for the day before the service.
+
+## Environment Variables
+Create a `.env` file from `env_example.txt` and provide these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID used to authenticate API calls. |
+| `TWILIO_AUTH_TOKEN` | Auth token paired with the SID. |
+| `TWILIO_PHONE_NUMBER` | Twilio phone number that sends reminders. |
+| `EMAIL_HOST` | SMTP server address (e.g., `smtp.gmail.com`). |
+| `EMAIL_PORT` | Port for the SMTP server. |
+| `EMAIL_USE_TLS` | `True` if the server requires TLS. |
+| `EMAIL_USERNAME` | Username or email address for SMTP authentication. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP authentication. |
+| `COMPANY_NAME` | Name displayed in confirmation messages. |
+| `COMPANY_EMAIL` | Sender address for confirmation emails. |
+
+## Running
+```bash
+pip install -r requirements.txt
+python service_reminder.py
+```
+Follow the prompts to schedule a reminder.

--- a/dentist_sms_system/README.md
+++ b/dentist_sms_system/README.md
@@ -32,7 +32,6 @@ cp env_example.txt .env
 
 # Edit .env with your credentials
 ```
-
 Required environment variables:
 ```
 TWILIO_ACCOUNT_SID=your_account_sid_here
@@ -41,6 +40,16 @@ TWILIO_PHONE_NUMBER=+1234567890
 OFFICE_NAME=Your Dental Office
 OFFICE_PHONE=+1234567890
 ```
+
+**Variable descriptions**
+
+| Variable | Purpose |
+|----------|---------|
+| `TWILIO_ACCOUNT_SID` | Twilio account identifier used for API calls. |
+| `TWILIO_AUTH_TOKEN` | Authentication token paired with the SID. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends appointment reminders. |
+| `OFFICE_NAME` | Name of the dental practice shown in messages. |
+| `OFFICE_PHONE` | Contact phone number displayed to patients. |
 
 ### 3. Get Twilio Credentials
 

--- a/email_system/README.md
+++ b/email_system/README.md
@@ -1,6 +1,6 @@
 # 📧 Simple Email Sending System
 
-This example demonstrates how to send an email using SMTP with a minimal Flask application. Configure your email credentials in `.env` and run the app to send yourself a welcome email.
+This minimal Flask app demonstrates sending email through an SMTP server. When you visit the web page and enter an address, the app sends a welcome email.
 
 ## Setup
 1. Copy `env_example.txt` to `.env` and fill in your SMTP settings.
@@ -12,4 +12,21 @@ This example demonstrates how to send an email using SMTP with a minimal Flask a
    ```bash
    python app.py
    ```
-4. Visit `http://localhost:5001` in your browser, enter your email address, and you will receive a test message.
+4. Open `http://localhost:5001` in your browser and submit your email address to test it.
+
+## Environment Variables
+The application expects these values in your `.env` file:
+
+| Variable | Description |
+|----------|-------------|
+| `EMAIL_HOST` | SMTP server address (e.g., `smtp.gmail.com`). |
+| `EMAIL_PORT` | Port for your SMTP server. |
+| `EMAIL_USE_TLS` | `True` if the server requires TLS. |
+| `EMAIL_USERNAME` | Username or email used to authenticate. |
+| `EMAIL_PASSWORD` | Password or app password for your email account. |
+| `COMPANY_NAME` | Name displayed in outgoing emails. |
+| `COMPANY_EMAIL` | Address used as the sender. |
+| `COMPANY_WEBSITE` | Website link included in the email footer. |
+| `SUPPORT_EMAIL` | Contact address for support inquiries. |
+| `FLASK_SECRET_KEY` | Secret key for Flask sessions. |
+| `FLASK_PORT` | Port number for running the app. |

--- a/event_registration_example/README.md
+++ b/event_registration_example/README.md
@@ -1,8 +1,30 @@
 # 🎫 Event Registration Example
 
-A simple registration demo that emails a ticket and sends a quick SMS reminder when a user signs up.
+This folder contains a short script that mimics registering a user for an event. When `event_notifier.py` runs it asks for the attendee's contact information, sends a ticket via email, and texts them a reminder using Twilio.
+
+## How It Works
+1. User details are collected on the command line.
+2. A confirmation email is sent through your SMTP server.
+3. A Twilio SMS reminder is sent with the event information.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set these variables:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Auth token for Twilio. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends the reminder. |
+| `EMAIL_HOST` | Address of your SMTP server. |
+| `EMAIL_PORT` | Port number for SMTP. |
+| `EMAIL_USE_TLS` | Use TLS (`True` or `False`). |
+| `EMAIL_USERNAME` | SMTP username or email. |
+| `EMAIL_PASSWORD` | SMTP password or app password. |
+| `COMPANY_NAME` | Name of the organization hosting the event. |
+| `COMPANY_EMAIL` | Sender address for confirmation emails. |
 
 ## Usage
-1. Configure `.env` using the provided template.
-2. Install dependencies with `pip install -r requirements.txt`.
-3. Run `python event_notifier.py` to simulate a registration.
+```bash
+pip install -r requirements.txt
+python event_notifier.py
+```

--- a/monthly_box_example/README.md
+++ b/monthly_box_example/README.md
@@ -1,8 +1,30 @@
 # 📦 Monthly Box Order Example
 
-This simple script simulates a subscription box order. When run, it asks for a customer's phone number and email address, then sends an email confirmation and a quick SMS using Twilio.
+This script simulates a customer subscribing to a monthly box. It collects the customer's phone number and email address, sends a confirmation email, and delivers a short SMS via Twilio.
+
+## How It Works
+1. The user enters their contact information when running `order_system.py`.
+2. The script uses your SMTP settings to send an email confirmation.
+3. A Twilio SMS is sent to let the customer know their first box is on the way.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and define the following:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID used for SMS. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number from which SMS notifications are sent. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether to use TLS for SMTP. |
+| `EMAIL_USERNAME` | Your email username or address. |
+| `EMAIL_PASSWORD` | Password or app password for your email account. |
+| `COMPANY_NAME` | Company name included in messages. |
+| `COMPANY_EMAIL` | Email address used as the sender. |
 
 ## Running
-1. Copy `env_example.txt` to `.env` and add your credentials.
-2. Install requirements: `pip install -r requirements.txt`
-3. Run the script: `python order_system.py`
+```bash
+pip install -r requirements.txt
+python order_system.py
+```

--- a/restaurant_reservation_example/README.md
+++ b/restaurant_reservation_example/README.md
@@ -1,8 +1,30 @@
 # 🍽️ Restaurant Reservation Example
 
-Collects reservation details and sends an email confirmation and SMS reminder.
+This example simulates taking a reservation for a restaurant. When you run `reservation_system.py` it gathers the guest's contact details, emails a confirmation, and sends a reminder text.
+
+## How It Works
+1. The script asks for the guest name, phone number, email address, and reservation time.
+2. An email confirmation is sent using your SMTP settings.
+3. A Twilio SMS reminder is sent on the day of the reservation.
+
+## Environment Variables
+After copying `env_example.txt` to `.env`, set the following:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID for sending SMS. |
+| `TWILIO_AUTH_TOKEN` | Auth token for the Twilio account. |
+| `TWILIO_PHONE_NUMBER` | Twilio number used to send reminders. |
+| `EMAIL_HOST` | SMTP server to send emails. |
+| `EMAIL_PORT` | Port number for the SMTP server. |
+| `EMAIL_USE_TLS` | Set to `True` if SMTP requires TLS. |
+| `EMAIL_USERNAME` | Username or address for SMTP authentication. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Restaurant name displayed in messages. |
+| `COMPANY_EMAIL` | Sender address for the confirmation email. |
 
 ## Run It
-1. Copy the `env_example.txt` to `.env` and edit it.
-2. Install with `pip install -r requirements.txt`.
-3. Run `python reservation_system.py`.
+```bash
+pip install -r requirements.txt
+python reservation_system.py
+```

--- a/support_ticket_example/README.md
+++ b/support_ticket_example/README.md
@@ -1,8 +1,31 @@
 # 🛠️ Support Ticket Notifier
 
-Simulates creating a support ticket. Customers receive an email and SMS confirmation, and the support team gets an email with ticket details.
+This example mimics a help desk system. Running `ticket_notifier.py` prompts the user for their issue. The customer receives an email and SMS confirming the ticket, while the support team gets an email with the details.
+
+## How It Works
+1. The script collects the customer's name, phone number, and a brief description of the issue.
+2. An email is sent to the customer and support team using your SMTP configuration.
+3. A confirmation SMS is sent to the customer using Twilio.
+
+## Environment Variables
+Create `.env` from `env_example.txt` and configure these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID used for SMS. |
+| `TWILIO_AUTH_TOKEN` | Twilio authentication token. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends confirmations. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether the server requires TLS. |
+| `EMAIL_USERNAME` | Username or address for SMTP login. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Name of the support organization. |
+| `COMPANY_EMAIL` | Email address used as the sender. |
+| `SUPPORT_PHONE` | Phone number displayed in support emails. |
 
 ## Steps
-1. Copy `env_example.txt` to `.env` and fill in your credentials.
-2. `pip install -r requirements.txt`
-3. Run `python ticket_notifier.py` and follow prompts.
+```bash
+pip install -r requirements.txt
+python ticket_notifier.py
+```

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,13 @@
+# 🗂️ Templates Folder
+
+This directory contains HTML templates used by `main.py`. The `index.html` file provides a small form that allows a user to submit a phone number and receive a joke and a piece of advice via SMS.
+
+The template relies on a few context variables passed from the Flask application:
+
+| Variable | Purpose |
+|----------|---------|
+| `success` | Boolean flag indicating if the SMS was sent successfully. |
+| `success_img` | URL for the success image displayed after sending. |
+| `phone_number` | The number entered by the user in the form. |
+
+No environment variables are required for the templates themselves, but the Flask app that renders them uses the Twilio credentials described in the main README.


### PR DESCRIPTION
## Summary
- add README to CallMeBot WhatsApp example and templates directory
- extend existing READMEs with overviews and variable explanations

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68475a0cac188327b14afde092c8e96a