### PR TITLE
Update docs index with links to examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,34 @@
 
 # Twilio Python Teaching Examples
 
-Welcome to **ULDataProfessor/sms-email-examples**! This repository contains several Python snippets that demonstrate how to use Twilio for SMS and email workflows. You can explore each example in the repository or browse the docs site generated from this folder.
+Welcome to **ULDataProfessor/sms-email-examples**! This collection showcases many different ways to integrate Twilio with Python. Each folder or file below links directly to the source so you can jump right into the code.
 
-Refer to the [README](../README.md) for setup instructions and a detailed overview of the available examples.
+Refer to the [README](../README.md) for setup instructions.
+
+## Quick Tour of Examples
+
+### Core Scripts
+
+- **[example_1_simple_sms.py](../example_1_simple_sms.py)** – send a single SMS message using environment variables.
+- **[example_2_interactive_menu.py](../example_2_interactive_menu.py)** – a command‑line menu that sends different message types.
+- **[example_3_bulk_sms.py](../example_3_bulk_sms.py)** – demonstrates batch messaging and tracking.
+- **[example_4_webhook_receiver.py](../example_4_webhook_receiver.py)** – Flask application that receives SMS webhooks and replies.
+- **[main.py](../main.py)** – full web application that texts jokes and advice to a user.
+
+### Business Scenario Folders
+
+- **[monthly_box_example/](../monthly_box_example/)** – order confirmation and SMS for a subscription box.
+- **[car_service_example/](../car_service_example/)** – email confirmation and scheduled service reminder texts.
+- **[event_registration_example/](../event_registration_example/)** – confirms event registration by email and sends a reminder SMS.
+- **[support_ticket_example/](../support_ticket_example/)** – notifies customers and support staff when a ticket is created.
+- **[restaurant_reservation_example/](../restaurant_reservation_example/)** – collects reservation info and sends a same‑day reminder.
+- **[email_system/](../email_system/)** – tiny Flask app for sending emails.
+- **[callmebot_whatsapp_example/](../callmebot_whatsapp_example/)** – examples for sending WhatsApp messages with CallMeBot.
+- **[dentist_sms_system/](../dentist_sms_system/)** – advanced appointment reminders with two‑way SMS.
+
+### Utilities
+
+- **[send_sms.py](../send_sms.py)** – helper function used by several scripts.
+- Templates for the web app live in **[templates/](../templates/)**.
+
+This documentation points to the full source so you can explore and experiment with each workflow.


### PR DESCRIPTION
## Summary
- expand `docs/index.md` with links that point to all the example code

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68475c9a29248327a1b2e19e7f17a450