### PR TITLE
Add industry-specific Twilio/email examples

### DIFF
--- a/clinic_follow_up_example/README.md
+++ b/clinic_follow_up_example/README.md
@@ -1,0 +1,30 @@
+# 🩺 Clinic Follow-Up Example
+
+After a medical appointment, clinics often send instructions to patients. `follow_up_sender.py` emails the detailed instructions and sends a quick SMS letting the patient know to check their inbox.
+
+## How It Works
+1. Enter the patient's phone, email and procedure name.
+2. The script emails follow-up instructions for that procedure.
+3. It also sends an SMS confirmation.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and configure:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number used for SMS notices. |
+| `EMAIL_HOST` | SMTP host. |
+| `EMAIL_PORT` | SMTP port. |
+| `EMAIL_USE_TLS` | Use TLS (`True`/`False`). |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `CLINIC_EMAIL` | Sender address for follow-ups. |
+| `CLINIC_NAME` | Clinic name used in messages. |
+
+## Run It
+```bash
+pip install -r requirements.txt
+python follow_up_sender.py
+```

--- a/clinic_follow_up_example/env_example.txt
+++ b/clinic_follow_up_example/env_example.txt
@@ -1,0 +1,10 @@
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE_NUMBER=+15551234567
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_USERNAME=your_email@example.com
+EMAIL_PASSWORD=your_email_password
+CLINIC_EMAIL=clinic@example.com
+CLINIC_NAME=Downtown Clinic

--- a/clinic_follow_up_example/follow_up_sender.py
+++ b/clinic_follow_up_example/follow_up_sender.py
@@ -1,0 +1,59 @@
+"""Clinic follow-up instructions by email and SMS."""
+
+import os
+from email.message import EmailMessage
+import smtplib
+from twilio.rest import Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
+EMAIL_USERNAME = os.getenv("EMAIL_USERNAME")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+CLINIC_EMAIL = os.getenv("CLINIC_EMAIL", "clinic@example.com")
+CLINIC_NAME = os.getenv("CLINIC_NAME", "Downtown Clinic")
+
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+TWILIO_PHONE_NUMBER = os.getenv("TWILIO_PHONE_NUMBER")
+client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+
+
+def send_email(to_addr: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = f"{CLINIC_NAME} <{CLINIC_EMAIL}>"
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+    with smtplib.SMTP(EMAIL_HOST, EMAIL_PORT) as server:
+        if EMAIL_USE_TLS:
+            server.starttls()
+        if EMAIL_USERNAME:
+            server.login(EMAIL_USERNAME, EMAIL_PASSWORD)
+        server.send_message(msg)
+
+
+def send_sms(to_number: str, body: str) -> None:
+    client.messages.create(body=body, from_=TWILIO_PHONE_NUMBER, to=to_number)
+
+
+def main() -> None:
+    print("=== Send Follow-Up Instructions ===")
+    phone = input("Patient phone (+1...): ")
+    email = input("Patient email: ")
+    procedure = input("Procedure name: ")
+
+    instructions = f"Thank you for visiting. Here are your {procedure} instructions."
+    send_email(email, f"{procedure} Follow-Up", instructions)
+    print("Follow-up email sent.")
+
+    sms_text = f"We emailed your {procedure} instructions. Stay well!"
+    send_sms(phone, sms_text)
+    print("SMS confirmation sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/clinic_follow_up_example/requirements.txt
+++ b/clinic_follow_up_example/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==1.0.0
+twilio==8.11.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,10 @@ Refer to the [README](../README.md) for setup instructions.
 - **[email_system/](../email_system/)** – tiny Flask app for sending emails.
 - **[callmebot_whatsapp_example/](../callmebot_whatsapp_example/)** – examples for sending WhatsApp messages with CallMeBot.
 - **[dentist_sms_system/](../dentist_sms_system/)** – advanced appointment reminders with two‑way SMS.
+- **[real_estate_showing_example/](../real_estate_showing_example/)** – schedule property showings and notify buyers.
+- **[gym_membership_example/](../gym_membership_example/)** – send renewal reminders to gym members.
+- **[farm_irrigation_example/](../farm_irrigation_example/)** – alert farmers in Lethbridge when crops need watering.
+- **[clinic_follow_up_example/](../clinic_follow_up_example/)** – email post‑visit instructions and SMS confirmations.
 
 ### Utilities
 

--- a/farm_irrigation_example/README.md
+++ b/farm_irrigation_example/README.md
@@ -1,0 +1,29 @@
+# 🚜 Farm Irrigation Alerts
+
+Designed for a farm near Lethbridge, Alberta, this example triggers an SMS and email when soil moisture levels drop too low. Run `irrigation_alerts.py` and enter the current moisture reading to see it in action.
+
+## Steps
+1. Enter the phone number and email for the farmer.
+2. Provide the field identifier and soil moisture percentage.
+3. If moisture is under 25%, a warning is sent via Twilio and email.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number that sends SMS. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP port. |
+| `EMAIL_USE_TLS` | Use TLS (`True`/`False`). |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `FARM_EMAIL` | Sender address for email alerts. |
+
+## Usage
+```bash
+pip install -r requirements.txt
+python irrigation_alerts.py
+```

--- a/farm_irrigation_example/env_example.txt
+++ b/farm_irrigation_example/env_example.txt
@@ -1,0 +1,9 @@
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE_NUMBER=+15551234567
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_USERNAME=your_email@example.com
+EMAIL_PASSWORD=your_email_password
+FARM_EMAIL=farm@example.com

--- a/farm_irrigation_example/irrigation_alerts.py
+++ b/farm_irrigation_example/irrigation_alerts.py
@@ -1,0 +1,59 @@
+"""Farm irrigation monitoring for Lethbridge, Alberta."""
+
+import os
+from twilio.rest import Client
+from dotenv import load_dotenv
+from email.message import EmailMessage
+import smtplib
+
+load_dotenv()
+
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+TWILIO_PHONE_NUMBER = os.getenv("TWILIO_PHONE_NUMBER")
+client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
+EMAIL_USERNAME = os.getenv("EMAIL_USERNAME")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+FARM_EMAIL = os.getenv("FARM_EMAIL", "farm@example.com")
+
+
+def send_sms(to_number: str, body: str) -> None:
+    client.messages.create(body=body, from_=TWILIO_PHONE_NUMBER, to=to_number)
+
+
+def send_email(to_addr: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = FARM_EMAIL
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+    with smtplib.SMTP(EMAIL_HOST, EMAIL_PORT) as server:
+        if EMAIL_USE_TLS:
+            server.starttls()
+        if EMAIL_USERNAME:
+            server.login(EMAIL_USERNAME, EMAIL_PASSWORD)
+        server.send_message(msg)
+
+
+def main() -> None:
+    print("=== Lethbridge Irrigation Alert ===")
+    phone = input("Farmer phone (+1...): ")
+    email = input("Farmer email: ")
+    field = input("Field name/number: ")
+    moisture = float(input("Current soil moisture (%): "))
+
+    if moisture < 25:
+        msg = f"Irrigation needed in {field}! Moisture at {moisture}%."
+        send_sms(phone, msg)
+        send_email(email, "Irrigation Alert", msg)
+        print("Alerts sent for low moisture.")
+    else:
+        print("Moisture level adequate; no alerts sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/farm_irrigation_example/requirements.txt
+++ b/farm_irrigation_example/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==1.0.0
+twilio==8.11.0

--- a/gym_membership_example/README.md
+++ b/gym_membership_example/README.md
@@ -1,0 +1,30 @@
+# 💪 Gym Membership Reminder
+
+`membership_reminder.py` sends both an email and an SMS to members whose gym membership is about to expire. It's a simple way to automate renewal notices with Twilio.
+
+## How It Works
+1. Collect the member's contact details and renewal date.
+2. Email them a friendly reminder to renew.
+3. Text them the same information via SMS.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number that sends SMS reminders. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | Port for SMTP. |
+| `EMAIL_USE_TLS` | `True` or `False` for TLS. |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `COMPANY_NAME` | Gym name used in messages. |
+| `COMPANY_EMAIL` | Sender address for the email reminder. |
+
+## Usage
+```bash
+pip install -r requirements.txt
+python membership_reminder.py
+```

--- a/gym_membership_example/env_example.txt
+++ b/gym_membership_example/env_example.txt
@@ -1,0 +1,10 @@
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE_NUMBER=+15551234567
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_USERNAME=your_email@example.com
+EMAIL_PASSWORD=your_email_password
+COMPANY_NAME=Super Gym
+COMPANY_EMAIL=noreply@gym.com

--- a/gym_membership_example/membership_reminder.py
+++ b/gym_membership_example/membership_reminder.py
@@ -1,0 +1,68 @@
+"""Send gym membership renewal reminders via email and SMS."""
+
+import os
+from email.message import EmailMessage
+import smtplib
+from twilio.rest import Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
+EMAIL_USERNAME = os.getenv("EMAIL_USERNAME")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+COMPANY_EMAIL = os.getenv("COMPANY_EMAIL", "noreply@gym.com")
+COMPANY_NAME = os.getenv("COMPANY_NAME", "Super Gym")
+
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+TWILIO_PHONE_NUMBER = os.getenv("TWILIO_PHONE_NUMBER")
+client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+
+
+def send_email(to_addr: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = f"{COMPANY_NAME} <{COMPANY_EMAIL}>"
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    with smtplib.SMTP(EMAIL_HOST, EMAIL_PORT) as server:
+        if EMAIL_USE_TLS:
+            server.starttls()
+        if EMAIL_USERNAME:
+            server.login(EMAIL_USERNAME, EMAIL_PASSWORD)
+        server.send_message(msg)
+
+
+def send_sms(to_number: str, body: str) -> None:
+    client.messages.create(
+        body=body,
+        from_=TWILIO_PHONE_NUMBER,
+        to=to_number,
+    )
+
+
+def main() -> None:
+    print("=== Membership Renewal Reminder ===")
+    phone = input("Member phone (+1...): ")
+    email = input("Member email: ")
+    due_date = input("Membership renewal date: ")
+
+    email_subject = "Your Gym Membership is Expiring"
+    email_body = (
+        f"Hi there, your membership expires on {due_date}. "
+        f"Renew soon to keep your access to {COMPANY_NAME}!"
+    )
+    send_email(email, email_subject, email_body)
+    print("Renewal email sent.")
+
+    sms_text = f"Reminder: your {COMPANY_NAME} membership renews on {due_date}."
+    send_sms(phone, sms_text)
+    print("SMS reminder sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gym_membership_example/requirements.txt
+++ b/gym_membership_example/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==1.0.0
+twilio==8.11.0

--- a/real_estate_showing_example/README.md
+++ b/real_estate_showing_example/README.md
@@ -1,0 +1,30 @@
+# 🏠 Real Estate Showing Example
+
+This demo shows how a real estate agent might schedule property showings. When you run `showing_notification.py`, it collects the buyer's phone number, email address, property location and showing time. It then sends an email confirmation and an SMS reminder.
+
+## How It Works
+1. Prompt the agent for buyer contact details and showing info.
+2. Send an email with the date, time and address of the showing.
+3. Text the buyer a short reminder using Twilio.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and fill in the following values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Auth token for Twilio. |
+| `TWILIO_PHONE_NUMBER` | Number that sends the SMS reminder. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether to use TLS with SMTP. |
+| `EMAIL_USERNAME` | Username or email for SMTP auth. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Name used in messages. |
+| `COMPANY_EMAIL` | Sender address for email confirmations. |
+
+## Running
+```bash
+pip install -r requirements.txt
+python showing_notification.py
+```

--- a/real_estate_showing_example/env_example.txt
+++ b/real_estate_showing_example/env_example.txt
@@ -1,0 +1,10 @@
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE_NUMBER=+15551234567
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_USERNAME=your_email@example.com
+EMAIL_PASSWORD=your_email_password
+COMPANY_NAME=Best Realty
+COMPANY_EMAIL=agent@example.com

--- a/real_estate_showing_example/requirements.txt
+++ b/real_estate_showing_example/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==1.0.0
+twilio==8.11.0

--- a/real_estate_showing_example/showing_notification.py
+++ b/real_estate_showing_example/showing_notification.py
@@ -1,0 +1,69 @@
+"""Real estate showing notification via email and SMS."""
+
+import os
+from email.message import EmailMessage
+import smtplib
+from twilio.rest import Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
+EMAIL_USERNAME = os.getenv("EMAIL_USERNAME")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+COMPANY_EMAIL = os.getenv("COMPANY_EMAIL", "agent@example.com")
+COMPANY_NAME = os.getenv("COMPANY_NAME", "Best Realty")
+
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+TWILIO_PHONE_NUMBER = os.getenv("TWILIO_PHONE_NUMBER")
+client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+
+
+def send_email(to_addr: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = f"{COMPANY_NAME} <{COMPANY_EMAIL}>"
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    with smtplib.SMTP(EMAIL_HOST, EMAIL_PORT) as server:
+        if EMAIL_USE_TLS:
+            server.starttls()
+        if EMAIL_USERNAME:
+            server.login(EMAIL_USERNAME, EMAIL_PASSWORD)
+        server.send_message(msg)
+
+
+def send_sms(to_number: str, body: str) -> None:
+    client.messages.create(
+        body=body,
+        from_=TWILIO_PHONE_NUMBER,
+        to=to_number,
+    )
+
+
+def main() -> None:
+    print("=== Schedule a Property Showing ===")
+    phone = input("Buyer phone (+1...): ")
+    email = input("Buyer email: ")
+    address = input("Property address: ")
+    when = input("Showing date/time: ")
+
+    email_subject = f"Showing Scheduled for {address}"
+    email_body = (
+        f"Hi, your showing at {address} is scheduled for {when}. "
+        f"Please reply if you need to reschedule."
+    )
+    send_email(email, email_subject, email_body)
+    print("Confirmation email sent.")
+
+    sms_text = f"Reminder: showing at {address} on {when}."
+    send_sms(phone, sms_text)
+    print("SMS reminder sent.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add four new business scenario examples using Twilio and email
  - real estate showing notifications
  - gym membership renewal reminders
  - farm irrigation alerts in Lethbridge, Alberta
  - clinic follow‑up instructions
- document the new examples in `docs/index.md`

## Testing
- `python -m py_compile real_estate_showing_example/showing_notification.py gym_membership_example/membership_reminder.py farm_irrigation_example/irrigation_alerts.py clinic_follow_up_example/follow_up_sender.py`

------
https://chatgpt.com/codex/tasks/task_e_68475d88f3f88327bb80e21e9d330189