### PR TITLE
Add documentation pages for each example

### DIFF
--- a/docs/callmebot_whatsapp_example.md
+++ b/docs/callmebot_whatsapp_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 📱 CallMeBot WhatsApp Example
+
+This folder demonstrates how to send WhatsApp messages using the free [CallMeBot](https://www.callmebot.com/) API. It includes two scripts:
+
+- `whatsapp_sender.py` – a helper class that sends messages through the CallMeBot API.
+- `webhook_server.py` – a Flask application that exposes webhook endpoints and triggers WhatsApp notifications.
+
+The example is designed for classroom use so students can experiment with WhatsApp automation without needing a Twilio WhatsApp account.
+
+## How It Works
+1. `whatsapp_sender.py` loads your credentials from `.env` and provides methods to send plain, emoji, or formatted messages.
+2. `webhook_server.py` receives POST requests at `/webhook/*` and uses `WhatsAppSender` to deliver the messages.
+3. You can run the server locally and expose it with ngrok for testing.
+
+## Environment Variables
+Create a `.env` file based on `env_example.txt` and set the following values:
+
+| Variable | Description |
+|----------|-------------|
+| `WHATSAPP_PHONE_NUMBER` | Your WhatsApp number (country code, no `+`). |
+| `CALLMEBOT_API_KEY` | API key obtained by messaging CallMeBot. |
+| `WEBHOOK_SECRET` | Optional secret used to verify incoming webhook signatures. |
+
+## Running the Demo
+```bash
+cd callmebot_whatsapp_example
+pip install -r requirements.txt
+python webhook_server.py
+```
+Visit `http://localhost:5000/webhook/test` to send a test message. Use `ngrok http 5000` if you want to receive webhooks from external services.
+

--- a/docs/car_service_example.md
+++ b/docs/car_service_example.md
@@ -1,0 +1,35 @@
+---
+---
+
+# 🚗 Car Service Reminder
+
+This example simulates an auto shop that collects customer contact details and a service date. It sends an email confirmation immediately and schedules an SMS reminder before the appointment.
+
+## How It Works
+1. The script prompts for the customer's phone number, email, and desired service date.
+2. An email confirmation is sent using the SMTP settings from your `.env` file.
+3. A Twilio SMS reminder is scheduled for the day before the service.
+
+## Environment Variables
+Create a `.env` file from `env_example.txt` and provide these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID used to authenticate API calls. |
+| `TWILIO_AUTH_TOKEN` | Auth token paired with the SID. |
+| `TWILIO_PHONE_NUMBER` | Twilio phone number that sends reminders. |
+| `EMAIL_HOST` | SMTP server address (e.g., `smtp.gmail.com`). |
+| `EMAIL_PORT` | Port for the SMTP server. |
+| `EMAIL_USE_TLS` | `True` if the server requires TLS. |
+| `EMAIL_USERNAME` | Username or email address for SMTP authentication. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP authentication. |
+| `COMPANY_NAME` | Name displayed in confirmation messages. |
+| `COMPANY_EMAIL` | Sender address for confirmation emails. |
+
+## Running
+```bash
+pip install -r requirements.txt
+python service_reminder.py
+```
+Follow the prompts to schedule a reminder.
+

--- a/docs/clinic_follow_up_example.md
+++ b/docs/clinic_follow_up_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 🩺 Clinic Follow-Up Example
+
+After a medical appointment, clinics often send instructions to patients. `follow_up_sender.py` emails the detailed instructions and sends a quick SMS letting the patient know to check their inbox.
+
+## How It Works
+1. Enter the patient's phone, email and procedure name.
+2. The script emails follow-up instructions for that procedure.
+3. It also sends an SMS confirmation.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and configure:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number used for SMS notices. |
+| `EMAIL_HOST` | SMTP host. |
+| `EMAIL_PORT` | SMTP port. |
+| `EMAIL_USE_TLS` | Use TLS (`True`/`False`). |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `CLINIC_EMAIL` | Sender address for follow-ups. |
+| `CLINIC_NAME` | Clinic name used in messages. |
+
+## Run It
+```bash
+pip install -r requirements.txt
+python follow_up_sender.py
+```
+

--- a/docs/dentist_sms_system.md
+++ b/docs/dentist_sms_system.md
@@ -1,0 +1,323 @@
+---
+---
+
+# 🦷 Dentist Office SMS Appointment System
+
+An automated SMS appointment reminder and response handling system built with Python, Flask, and Twilio. This system sends appointment reminders to patients and allows them to confirm, reschedule, or cancel appointments via SMS responses.
+
+## 📋 Features
+
+- **Automated Appointment Reminders**: Sends SMS reminders 24 hours before appointments
+- **Patient Response Handling**: Processes confirmation, reschedule, and cancellation requests
+- **Two-Way SMS Communication**: Patients can interact with the system via text messages
+- **Reschedule Options**: Provides available time slots when patients request reschedules
+- **Web Dashboard**: View all appointments and system status
+- **Webhook Integration**: Uses ngrok for local development and testing
+- **Persistent Storage**: JSON-based appointment storage (easily upgradeable to database)
+
+## 🚀 Quick Start
+
+### 1. Installation
+
+```bash
+# Clone the repository
+cd dentist_sms_system
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### 2. Configuration
+
+```bash
+# Copy environment template
+cp env_example.txt .env
+
+# Edit .env with your credentials
+```
+Required environment variables:
+```
+TWILIO_ACCOUNT_SID=your_account_sid_here
+TWILIO_AUTH_TOKEN=your_auth_token_here
+TWILIO_PHONE_NUMBER=+1234567890
+OFFICE_NAME=Your Dental Office
+OFFICE_PHONE=+1234567890
+```
+
+**Variable descriptions**
+
+| Variable | Purpose |
+|----------|---------|
+| `TWILIO_ACCOUNT_SID` | Twilio account identifier used for API calls. |
+| `TWILIO_AUTH_TOKEN` | Authentication token paired with the SID. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends appointment reminders. |
+| `OFFICE_NAME` | Name of the dental practice shown in messages. |
+| `OFFICE_PHONE` | Contact phone number displayed to patients. |
+
+### 3. Get Twilio Credentials
+
+1. Sign up at [twilio.com](https://www.twilio.com)
+2. Go to [Twilio Console](https://console.twilio.com)
+3. Copy your Account SID and Auth Token
+4. Purchase a phone number
+
+### 4. Run the System
+
+```bash
+# Start the Flask server
+python app.py
+```
+
+### 5. Expose with ngrok
+
+```bash
+# In another terminal
+ngrok http 5000
+```
+
+### 6. Configure Twilio Webhook
+
+1. Go to [Twilio Console](https://console.twilio.com)
+2. Navigate to Phone Numbers → Manage → Active numbers
+3. Click on your Twilio number
+4. Set webhook URL to: `https://your-ngrok-url.ngrok.io/webhook/sms`
+5. Set HTTP method to `POST`
+
+## 📱 Patient SMS Commands
+
+Patients can respond to appointment reminders with:
+
+| Command | Action |
+|---------|--------|
+| `CONFIRM` or `YES` | Confirm the appointment |
+| `RESCHEDULE` or `CHANGE` | Request to reschedule |
+| `CANCEL` or `NO` | Cancel the appointment |
+| `1-5` | Select a reschedule option (after requesting reschedule) |
+
+## 🌐 API Endpoints
+
+### Main Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/` | Dashboard with appointment overview |
+| `POST` | `/webhook/sms` | Main SMS webhook (set in Twilio) |
+| `GET/POST` | `/webhook/test` | Test webhook functionality |
+| `POST` | `/send-reminders` | Manually trigger reminders |
+| `GET` | `/appointments` | View all appointments (JSON) |
+| `POST` | `/add-appointment` | Add new appointment |
+
+### Example API Usage
+
+#### Add Appointment
+```bash
+curl -X POST http://localhost:5000/add-appointment \
+  -H "Content-Type: application/json" \
+  -d '{
+    "appointment_id": "APT004",
+    "patient_name": "Alice Johnson",
+    "patient_phone": "+1555123456",
+    "appointment_date": "2024-01-15",
+    "appointment_time": "14:00",
+    "service": "Teeth Cleaning"
+  }'
+```
+
+#### Trigger Reminders
+```bash
+curl -X POST http://localhost:5000/send-reminders
+```
+
+## 🏗️ System Architecture
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Twilio SMS    │───▶│  Flask Webhook   │───▶│  Appointment    │
+│    Gateway      │    │     Server       │    │    Manager      │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+                                │
+                                ▼
+                       ┌──────────────────┐
+                       │   SMS Service    │
+                       │  (Send/Receive)  │
+                       └──────────────────┘
+```
+
+### Core Components
+
+1. **`appointment_manager.py`**: Handles appointment storage and operations
+2. **`sms_service.py`**: Manages Twilio SMS sending and response processing
+3. **`app.py`**: Flask web server with webhook endpoints
+4. **`appointments.json`**: Persistent storage for appointment data
+
+## 📊 Sample Messages
+
+### Appointment Reminder
+```
+🦷 Sunny Dental Care Reminder
+
+Hi John Smith!
+
+You have an appointment for Cleaning tomorrow (Monday, January 15, 2024 at 10:00 AM).
+
+Please reply:
+• CONFIRM to confirm your appointment
+• RESCHEDULE to change the date/time
+• CANCEL to cancel your appointment
+
+Questions? Call us at +1234567890
+```
+
+### Reschedule Options
+```
+📅 Reschedule Request Received
+
+Current appointment: Cleaning on Monday, January 15, 2024 at 10:00 AM
+
+Available slots:
+1. Tuesday, 01/16 at 09:00 AM
+2. Tuesday, 01/16 at 02:00 PM
+3. Wednesday, 01/17 at 11:00 AM
+4. Thursday, 01/18 at 10:00 AM
+5. Friday, 01/19 at 03:00 PM
+
+Reply with the number (1-5) of your preferred slot, or call us for more options.
+
+Call: +1234567890
+```
+
+## 🔧 Configuration Options
+
+### Office Hours
+Modify in `appointment_manager.py`:
+```python
+all_slots = [
+    "09:00", "10:00", "11:00", "12:00",
+    "13:00", "14:00", "15:00", "16:00", "17:00"
+]
+```
+
+### Reminder Schedule
+Modify in `app.py`:
+```python
+schedule.every().day.at("09:00").do(sms_service.send_bulk_reminders)
+```
+
+### Message Templates
+Customize messages in `sms_service.py` methods:
+- `_create_reminder_message()`
+- `_handle_confirmation()`
+- `_handle_reschedule_request()`
+- `_handle_cancellation()`
+
+## 🧪 Testing
+
+### Test SMS Processing
+```bash
+# Test appointment reminder creation
+python appointment_manager.py
+
+# Test SMS service
+python sms_service.py
+
+# Test webhook with curl
+curl -X POST http://localhost:5000/webhook/test
+```
+
+### Simulate Patient Responses
+```bash
+# Test confirmation
+curl -X POST http://localhost:5000/webhook/sms \
+  -d "From=+1234567890&Body=CONFIRM"
+
+# Test reschedule request
+curl -X POST http://localhost:5000/webhook/sms \
+  -d "From=+1234567890&Body=RESCHEDULE"
+```
+
+## 📈 Production Deployment
+
+### Database Upgrade
+Replace JSON storage with PostgreSQL/MySQL:
+
+```python
+# In appointment_manager.py
+import psycopg2
+# Replace file operations with database queries
+```
+
+### Environment Variables
+Set production environment variables:
+```bash
+DATABASE_URL=postgresql://user:pass@host:port/dbname
+FLASK_ENV=production
+```
+
+### Deployment Options
+- **Heroku**: Easy deployment with PostgreSQL addon
+- **AWS EC2**: Full control with RDS database
+- **DigitalOcean**: Simple deployment with managed database
+- **Railway**: Modern deployment platform
+
+## 🛡️ Security Considerations
+
+- **Webhook Validation**: Verify Twilio signatures in production
+- **Rate Limiting**: Implement rate limits for API endpoints  
+- **Data Encryption**: Encrypt sensitive patient data
+- **HTTPS Only**: Use SSL certificates in production
+- **Access Control**: Implement authentication for admin endpoints
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+1. **SMS not sending**: Check Twilio credentials and phone number format
+2. **Webhook not receiving**: Verify ngrok URL and Twilio configuration
+3. **Appointments not saving**: Check file permissions for `appointments.json`
+4. **Reminder scheduling**: Ensure scheduler thread is running
+
+### Debug Mode
+Enable debug logging:
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### Log Files
+Monitor application logs:
+```bash
+tail -f app.log
+```
+
+## 📚 Extensions
+
+### Possible Enhancements
+- Email notifications alongside SMS
+- Multi-language support
+- Insurance verification integration
+- Payment reminders
+- Automated follow-up surveys
+- Integration with practice management software
+
+### Advanced Features
+- AI-powered appointment scheduling
+- Voice call reminders
+- WhatsApp integration
+- Calendar synchronization
+- Analytics dashboard
+
+## 📄 License
+
+This project is created for educational purposes. Feel free to use and modify for your dental practice needs.
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Commit your changes
+4. Push to the branch
+5. Create a Pull Request
+
+---
+
+**Made with 🦷 for better dental practice management** 

--- a/docs/email_system.md
+++ b/docs/email_system.md
@@ -1,0 +1,36 @@
+---
+---
+
+# 📧 Simple Email Sending System
+
+This minimal Flask app demonstrates sending email through an SMTP server. When you visit the web page and enter an address, the app sends a welcome email.
+
+## Setup
+1. Copy `env_example.txt` to `.env` and fill in your SMTP settings.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the server:
+   ```bash
+   python app.py
+   ```
+4. Open `http://localhost:5001` in your browser and submit your email address to test it.
+
+## Environment Variables
+The application expects these values in your `.env` file:
+
+| Variable | Description |
+|----------|-------------|
+| `EMAIL_HOST` | SMTP server address (e.g., `smtp.gmail.com`). |
+| `EMAIL_PORT` | Port for your SMTP server. |
+| `EMAIL_USE_TLS` | `True` if the server requires TLS. |
+| `EMAIL_USERNAME` | Username or email used to authenticate. |
+| `EMAIL_PASSWORD` | Password or app password for your email account. |
+| `COMPANY_NAME` | Name displayed in outgoing emails. |
+| `COMPANY_EMAIL` | Address used as the sender. |
+| `COMPANY_WEBSITE` | Website link included in the email footer. |
+| `SUPPORT_EMAIL` | Contact address for support inquiries. |
+| `FLASK_SECRET_KEY` | Secret key for Flask sessions. |
+| `FLASK_PORT` | Port number for running the app. |
+

--- a/docs/event_registration_example.md
+++ b/docs/event_registration_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 🎫 Event Registration Example
+
+This folder contains a short script that mimics registering a user for an event. When `event_notifier.py` runs it asks for the attendee's contact information, sends a ticket via email, and texts them a reminder using Twilio.
+
+## How It Works
+1. User details are collected on the command line.
+2. A confirmation email is sent through your SMTP server.
+3. A Twilio SMS reminder is sent with the event information.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set these variables:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Auth token for Twilio. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends the reminder. |
+| `EMAIL_HOST` | Address of your SMTP server. |
+| `EMAIL_PORT` | Port number for SMTP. |
+| `EMAIL_USE_TLS` | Use TLS (`True` or `False`). |
+| `EMAIL_USERNAME` | SMTP username or email. |
+| `EMAIL_PASSWORD` | SMTP password or app password. |
+| `COMPANY_NAME` | Name of the organization hosting the event. |
+| `COMPANY_EMAIL` | Sender address for confirmation emails. |
+
+## Usage
+```bash
+pip install -r requirements.txt
+python event_notifier.py
+```
+

--- a/docs/example_1_simple_sms.md
+++ b/docs/example_1_simple_sms.md
@@ -1,0 +1,13 @@
+---
+---
+
+# Simple SMS Sender
+
+This page explains the basics of sending a text message with Twilio using [example_1_simple_sms.py](../example_1_simple_sms.py).
+
+```bash
+python example_1_simple_sms.py
+```
+
+The script loads your Twilio credentials from a `.env` file, prompts for a destination phone number and sends a friendly SMS.
+

--- a/docs/example_2_interactive_menu.md
+++ b/docs/example_2_interactive_menu.md
@@ -1,0 +1,13 @@
+---
+---
+
+# Interactive SMS Menu
+
+`example_2_interactive_menu.py` shows how to build a simple menu-driven tool for sending different kinds of SMS messages.
+
+```bash
+python example_2_interactive_menu.py
+```
+
+Choose options like motivational quotes or fun facts and the script sends them via Twilio.
+

--- a/docs/example_3_bulk_sms.md
+++ b/docs/example_3_bulk_sms.md
@@ -1,0 +1,13 @@
+---
+---
+
+# Bulk SMS Sender
+
+The script [example_3_bulk_sms.py](../example_3_bulk_sms.py) demonstrates sending personalized messages to a list of recipients.
+
+```bash
+python example_3_bulk_sms.py
+```
+
+It loops over phone numbers, sends each a message and prints the delivery status.
+

--- a/docs/example_4_webhook_receiver.md
+++ b/docs/example_4_webhook_receiver.md
@@ -1,0 +1,13 @@
+---
+---
+
+# Webhook Receiver
+
+`example_4_webhook_receiver.py` starts a small Flask app that listens for incoming SMS messages and status callbacks.
+
+```bash
+python example_4_webhook_receiver.py
+```
+
+Use a tool like ngrok to expose the local server while testing.
+

--- a/docs/farm_irrigation_example.md
+++ b/docs/farm_irrigation_example.md
@@ -1,0 +1,33 @@
+---
+---
+
+# 🚜 Farm Irrigation Alerts
+
+Designed for a farm near Lethbridge, Alberta, this example triggers an SMS and email when soil moisture levels drop too low. Run `irrigation_alerts.py` and enter the current moisture reading to see it in action.
+
+## Steps
+1. Enter the phone number and email for the farmer.
+2. Provide the field identifier and soil moisture percentage.
+3. If moisture is under 25%, a warning is sent via Twilio and email.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number that sends SMS. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP port. |
+| `EMAIL_USE_TLS` | Use TLS (`True`/`False`). |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `FARM_EMAIL` | Sender address for email alerts. |
+
+## Usage
+```bash
+pip install -r requirements.txt
+python irrigation_alerts.py
+```
+

--- a/docs/gym_membership_example.md
+++ b/docs/gym_membership_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 💪 Gym Membership Reminder
+
+`membership_reminder.py` sends both an email and an SMS to members whose gym membership is about to expire. It's a simple way to automate renewal notices with Twilio.
+
+## How It Works
+1. Collect the member's contact details and renewal date.
+2. Email them a friendly reminder to renew.
+3. Text them the same information via SMS.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and set these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number that sends SMS reminders. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | Port for SMTP. |
+| `EMAIL_USE_TLS` | `True` or `False` for TLS. |
+| `EMAIL_USERNAME` | SMTP username. |
+| `EMAIL_PASSWORD` | SMTP password. |
+| `COMPANY_NAME` | Gym name used in messages. |
+| `COMPANY_EMAIL` | Sender address for the email reminder. |
+
+## Usage
+```bash
+pip install -r requirements.txt
+python membership_reminder.py
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 
 # Twilio Python Teaching Examples
 
-Welcome to **ULDataProfessor/sms-email-examples**! This collection showcases many different ways to integrate Twilio with Python. Each folder or file below links directly to the source so you can jump right into the code.
+Welcome to **ULDataProfessor/sms-email-examples**! This collection showcases many different ways to integrate Twilio with Python. Each link below points to a detailed documentation page so you can explore the code and workflow.
 
 Refer to the [README](../README.md) for setup instructions.
 
@@ -11,26 +11,26 @@ Refer to the [README](../README.md) for setup instructions.
 
 ### Core Scripts
 
-- **[example_1_simple_sms.py](../example_1_simple_sms.py)** – send a single SMS message using environment variables.
-- **[example_2_interactive_menu.py](../example_2_interactive_menu.py)** – a command‑line menu that sends different message types.
-- **[example_3_bulk_sms.py](../example_3_bulk_sms.py)** – demonstrates batch messaging and tracking.
-- **[example_4_webhook_receiver.py](../example_4_webhook_receiver.py)** – Flask application that receives SMS webhooks and replies.
-- **[main.py](../main.py)** – full web application that texts jokes and advice to a user.
+- **[Simple SMS](example_1_simple_sms.md)** – send a single SMS message using environment variables.
+- **[Interactive Menu](example_2_interactive_menu.md)** – a command‑line menu that sends different message types.
+- **[Bulk SMS](example_3_bulk_sms.md)** – demonstrates batch messaging and tracking.
+- **[Webhook Receiver](example_4_webhook_receiver.md)** – Flask application that receives SMS webhooks and replies.
+- **[SMS Web App](main.md)** – full web application that texts jokes and advice to a user.
 
 ### Business Scenario Folders
 
-- **[monthly_box_example/](../monthly_box_example/)** – order confirmation and SMS for a subscription box.
-- **[car_service_example/](../car_service_example/)** – email confirmation and scheduled service reminder texts.
-- **[event_registration_example/](../event_registration_example/)** – confirms event registration by email and sends a reminder SMS.
-- **[support_ticket_example/](../support_ticket_example/)** – notifies customers and support staff when a ticket is created.
-- **[restaurant_reservation_example/](../restaurant_reservation_example/)** – collects reservation info and sends a same‑day reminder.
-- **[email_system/](../email_system/)** – tiny Flask app for sending emails.
-- **[callmebot_whatsapp_example/](../callmebot_whatsapp_example/)** – examples for sending WhatsApp messages with CallMeBot.
-- **[dentist_sms_system/](../dentist_sms_system/)** – advanced appointment reminders with two‑way SMS.
-- **[real_estate_showing_example/](../real_estate_showing_example/)** – schedule property showings and notify buyers.
-- **[gym_membership_example/](../gym_membership_example/)** – send renewal reminders to gym members.
-- **[farm_irrigation_example/](../farm_irrigation_example/)** – alert farmers in Lethbridge when crops need watering.
-- **[clinic_follow_up_example/](../clinic_follow_up_example/)** – email post‑visit instructions and SMS confirmations.
+- **[Monthly Box Example](monthly_box_example.md)** – order confirmation and SMS for a subscription box.
+- **[Car Service Example](car_service_example.md)** – email confirmation and scheduled service reminder texts.
+- **[Event Registration Example](event_registration_example.md)** – confirms event registration by email and sends a reminder SMS.
+- **[Support Ticket Example](support_ticket_example.md)** – notifies customers and support staff when a ticket is created.
+- **[Restaurant Reservation Example](restaurant_reservation_example.md)** – collects reservation info and sends a same‑day reminder.
+- **[Email System](email_system.md)** – tiny Flask app for sending emails.
+- **[CallMeBot WhatsApp Example](callmebot_whatsapp_example.md)** – examples for sending WhatsApp messages with CallMeBot.
+- **[Dentist SMS System](dentist_sms_system.md)** – advanced appointment reminders with two‑way SMS.
+- **[Real Estate Showing Example](real_estate_showing_example.md)** – schedule property showings and notify buyers.
+- **[Gym Membership Example](gym_membership_example.md)** – send renewal reminders to gym members.
+- **[Farm Irrigation Example](farm_irrigation_example.md)** – alert farmers in Lethbridge when crops need watering.
+- **[Clinic Follow Up Example](clinic_follow_up_example.md)** – email post‑visit instructions and SMS confirmations.
 
 ### Utilities
 
@@ -38,3 +38,4 @@ Refer to the [README](../README.md) for setup instructions.
 - Templates for the web app live in **[templates/](../templates/)**.
 
 This documentation points to the full source so you can explore and experiment with each workflow.
+

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,0 +1,13 @@
+---
+---
+
+# SMS Web Application
+
+The [main.py](../main.py) file is a small Flask web app that sends jokes or advice to a phone number you enter on the page.
+
+```bash
+python main.py
+```
+
+Open your browser to `http://localhost:8080/` and explore the form-driven interface.
+

--- a/docs/monthly_box_example.md
+++ b/docs/monthly_box_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 📦 Monthly Box Order Example
+
+This script simulates a customer subscribing to a monthly box. It collects the customer's phone number and email address, sends a confirmation email, and delivers a short SMS via Twilio.
+
+## How It Works
+1. The user enters their contact information when running `order_system.py`.
+2. The script uses your SMTP settings to send an email confirmation.
+3. A Twilio SMS is sent to let the customer know their first box is on the way.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and define the following:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID used for SMS. |
+| `TWILIO_AUTH_TOKEN` | Twilio auth token. |
+| `TWILIO_PHONE_NUMBER` | Number from which SMS notifications are sent. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether to use TLS for SMTP. |
+| `EMAIL_USERNAME` | Your email username or address. |
+| `EMAIL_PASSWORD` | Password or app password for your email account. |
+| `COMPANY_NAME` | Company name included in messages. |
+| `COMPANY_EMAIL` | Email address used as the sender. |
+
+## Running
+```bash
+pip install -r requirements.txt
+python order_system.py
+```
+

--- a/docs/real_estate_showing_example.md
+++ b/docs/real_estate_showing_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 🏠 Real Estate Showing Example
+
+This demo shows how a real estate agent might schedule property showings. When you run `showing_notification.py`, it collects the buyer's phone number, email address, property location and showing time. It then sends an email confirmation and an SMS reminder.
+
+## How It Works
+1. Prompt the agent for buyer contact details and showing info.
+2. Send an email with the date, time and address of the showing.
+3. Text the buyer a short reminder using Twilio.
+
+## Environment Variables
+Copy `env_example.txt` to `.env` and fill in the following values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Your Twilio account SID. |
+| `TWILIO_AUTH_TOKEN` | Auth token for Twilio. |
+| `TWILIO_PHONE_NUMBER` | Number that sends the SMS reminder. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether to use TLS with SMTP. |
+| `EMAIL_USERNAME` | Username or email for SMTP auth. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Name used in messages. |
+| `COMPANY_EMAIL` | Sender address for email confirmations. |
+
+## Running
+```bash
+pip install -r requirements.txt
+python showing_notification.py
+```
+

--- a/docs/restaurant_reservation_example.md
+++ b/docs/restaurant_reservation_example.md
@@ -1,0 +1,34 @@
+---
+---
+
+# 🍽️ Restaurant Reservation Example
+
+This example simulates taking a reservation for a restaurant. When you run `reservation_system.py` it gathers the guest's contact details, emails a confirmation, and sends a reminder text.
+
+## How It Works
+1. The script asks for the guest name, phone number, email address, and reservation time.
+2. An email confirmation is sent using your SMTP settings.
+3. A Twilio SMS reminder is sent on the day of the reservation.
+
+## Environment Variables
+After copying `env_example.txt` to `.env`, set the following:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID for sending SMS. |
+| `TWILIO_AUTH_TOKEN` | Auth token for the Twilio account. |
+| `TWILIO_PHONE_NUMBER` | Twilio number used to send reminders. |
+| `EMAIL_HOST` | SMTP server to send emails. |
+| `EMAIL_PORT` | Port number for the SMTP server. |
+| `EMAIL_USE_TLS` | Set to `True` if SMTP requires TLS. |
+| `EMAIL_USERNAME` | Username or address for SMTP authentication. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Restaurant name displayed in messages. |
+| `COMPANY_EMAIL` | Sender address for the confirmation email. |
+
+## Run It
+```bash
+pip install -r requirements.txt
+python reservation_system.py
+```
+

--- a/docs/support_ticket_example.md
+++ b/docs/support_ticket_example.md
@@ -1,0 +1,35 @@
+---
+---
+
+# 🛠️ Support Ticket Notifier
+
+This example mimics a help desk system. Running `ticket_notifier.py` prompts the user for their issue. The customer receives an email and SMS confirming the ticket, while the support team gets an email with the details.
+
+## How It Works
+1. The script collects the customer's name, phone number, and a brief description of the issue.
+2. An email is sent to the customer and support team using your SMTP configuration.
+3. A confirmation SMS is sent to the customer using Twilio.
+
+## Environment Variables
+Create `.env` from `env_example.txt` and configure these values:
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio account SID used for SMS. |
+| `TWILIO_AUTH_TOKEN` | Twilio authentication token. |
+| `TWILIO_PHONE_NUMBER` | Twilio number that sends confirmations. |
+| `EMAIL_HOST` | SMTP server address. |
+| `EMAIL_PORT` | SMTP server port. |
+| `EMAIL_USE_TLS` | Whether the server requires TLS. |
+| `EMAIL_USERNAME` | Username or address for SMTP login. |
+| `EMAIL_PASSWORD` | Password or app password for SMTP. |
+| `COMPANY_NAME` | Name of the support organization. |
+| `COMPANY_EMAIL` | Email address used as the sender. |
+| `SUPPORT_PHONE` | Phone number displayed in support emails. |
+
+## Steps
+```bash
+pip install -r requirements.txt
+python ticket_notifier.py
+```
+


### PR DESCRIPTION
## Summary
- add individual Markdown pages under `docs/` for each project
- link to these new pages from `docs/index.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twilio')*

------
https://chatgpt.com/codex/tasks/task_e_68475e945fcc83278f2218f32cc3215f