### PR TITLE
Add AI automation API examples

### DIFF
--- a/ai_automation/chatgpt_generation/README.md
+++ b/ai_automation/chatgpt_generation/README.md
@@ -1,0 +1,18 @@
+# ChatGPT API Example
+
+This folder contains a simple example of using OpenAI's ChatGPT API.
+
+## File
+
+- `generate_text_with_chatgpt.py` – Sends a question to ChatGPT and prints the response.
+
+## Usage
+
+1. Install the `openai` Python package.
+2. Set the `OPENAI_API_KEY` environment variable with your OpenAI API key.
+3. Run the script:
+   ```bash
+   python generate_text_with_chatgpt.py
+   ```
+
+The program will request an explanation of recursion and display ChatGPT's answer.

--- a/ai_automation/chatgpt_generation/generate_text_with_chatgpt.py
+++ b/ai_automation/chatgpt_generation/generate_text_with_chatgpt.py
@@ -1,0 +1,19 @@
+import os
+import openai
+
+# Example using the OpenAI API (ChatGPT) to generate text.
+# Requires the openai package and a valid API key in OPENAI_API_KEY.
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+if not openai.api_key:
+    raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
+prompt = "Explain the concept of recursion in Python in two sentences."
+
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": prompt}]
+)
+
+print(response.choices[0].message["content"].strip())

--- a/ai_automation/google_genai/README.md
+++ b/ai_automation/google_genai/README.md
@@ -1,0 +1,18 @@
+# Google Generative AI Example
+
+This folder demonstrates how to call Google's generative AI API to create code snippets.
+
+## File
+
+- `generate_code_with_google.py` – Uses the `google.generativeai` library to request a Python function from the API.
+
+## Usage
+
+1. Install the `google-generativeai` package.
+2. Set the `GOOGLE_API_KEY` environment variable with your API key.
+3. Run the script:
+   ```bash
+   python generate_code_with_google.py
+   ```
+
+The program sends a prompt asking for a factorial function and prints the AI-generated code.

--- a/ai_automation/google_genai/generate_code_with_google.py
+++ b/ai_automation/google_genai/generate_code_with_google.py
@@ -1,0 +1,24 @@
+import os
+
+# Example of using Google Generative AI to produce a simple code snippet.
+# This script uses the google.generativeai Python library (Gemini/PaLM models).
+# You will need a valid API key from Google Cloud.
+
+import google.generativeai as genai
+
+API_KEY = os.getenv("GOOGLE_API_KEY")
+
+if not API_KEY:
+    raise EnvironmentError("GOOGLE_API_KEY environment variable not set")
+
+# Configure the client with your API key
+client = genai.Client(api_key=API_KEY)
+
+prompt = (
+    "Write a Python function that calculates the factorial of a number. "
+    "Include docstrings and type hints."
+)
+
+response = client.generate_text(prompt=prompt, model="models/text-bison-001")
+
+print(response.text)

--- a/ai_automation/midjourney_images/README.md
+++ b/ai_automation/midjourney_images/README.md
@@ -1,0 +1,20 @@
+# Midjourney Image Generation Example
+
+This folder shows a basic approach to calling a Midjourney-style API to create images.
+
+Midjourney itself does not offer an official API. Some third-party services expose a compatible endpoint, so this example uses a generic HTTP request.
+
+## File
+
+- `generate_image_midjourney.py` – Sends a prompt to an API URL and prints the image URL returned by the service.
+
+## Usage
+
+1. Install the `requests` library.
+2. Set the `MIDJOURNEY_API_URL` and `MIDJOURNEY_API_KEY` environment variables.
+3. Run the script:
+   ```bash
+   python generate_image_midjourney.py
+   ```
+
+The script posts a prompt describing a futuristic city and prints the URL of the generated image.

--- a/ai_automation/midjourney_images/generate_image_midjourney.py
+++ b/ai_automation/midjourney_images/generate_image_midjourney.py
@@ -1,0 +1,26 @@
+import os
+import requests
+
+# Example of sending a prompt to a Midjourney-like API to generate an image.
+# Midjourney does not have an official public API. This sample illustrates how
+# you might call a third-party service that exposes Midjourney functionality.
+
+API_URL = os.getenv("MIDJOURNEY_API_URL")  # e.g. https://api.midjourney-proxy.xyz/imagine
+API_KEY = os.getenv("MIDJOURNEY_API_KEY")
+
+if not API_URL or not API_KEY:
+    raise EnvironmentError("MIDJOURNEY_API_URL and MIDJOURNEY_API_KEY must be set")
+
+prompt = "A futuristic city skyline at sunset"
+
+response = requests.post(
+    API_URL,
+    headers={"Authorization": f"Bearer {API_KEY}"},
+    json={"prompt": prompt}
+)
+
+response.raise_for_status()
+
+# The API might return a URL to the generated image
+result = response.json()
+print("Image URL:", result.get("image_url"))


### PR DESCRIPTION
## Summary
- add `ai_automation` examples for Google generative AI, ChatGPT, and Midjourney style API
- include README documentation for each example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twilio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0cdb38dc8327a5a3dea7ac6c4541