### PR TITLE
Add AI automation pipeline examples

### DIFF
--- a/ai_automation/accounting_firm/README.md
+++ b/ai_automation/accounting_firm/README.md
@@ -1,0 +1,19 @@
+---
+---
+
+# 📊 Accounting Firm AI Pipeline Example
+
+`pipeline.py` demonstrates a minimal invoice processing workflow. It reads a CSV of invoices, identifies those that remain unpaid, generates reminder messages, and prints them.
+
+## Sample CSV format
+```
+client,amount,paid
+Acme,500,no
+Foo Corp,300,yes
+```
+
+## Running
+```bash
+python pipeline.py
+```
+Specify the path to your invoice CSV when prompted.

--- a/ai_automation/accounting_firm/pipeline.py
+++ b/ai_automation/accounting_firm/pipeline.py
@@ -1,0 +1,37 @@
+"""Accounting firm invoice pipeline demonstration."""
+
+import csv
+from typing import List, Dict
+
+def ingest_data(path: str) -> List[Dict[str, str]]:
+    """Read invoice data from a CSV file."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+def analyze_data(invoices: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Select unpaid invoices."""
+    return [inv for inv in invoices if inv.get("paid", "no").lower() != "yes"]
+
+def process_data(unpaid: List[Dict[str, str]]) -> List[str]:
+    """Prepare reminder messages."""
+    messages = []
+    for inv in unpaid:
+        client = inv.get("client", "Client")
+        amount = inv.get("amount", "0")
+        messages.append(f"Reminder: {client} owes ${amount}.")
+    return messages
+
+def output_results(messages: List[str]) -> None:
+    for msg in messages:
+        print(msg)
+
+def main() -> None:
+    path = input("Path to invoice CSV: ")
+    invoices = ingest_data(path)
+    unpaid = analyze_data(invoices)
+    messages = process_data(unpaid)
+    output_results(messages)
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/bank/README.md
+++ b/ai_automation/bank/README.md
@@ -1,0 +1,19 @@
+---
+---
+
+# 🏦 Bank AI Pipeline Example
+
+This example illustrates a basic workflow for analyzing bank transactions. The script `pipeline.py` reads a CSV file of transactions, flags any that exceed $10,000, processes them into a short report, and prints the results.
+
+## Sample CSV format
+```
+id,amount,account
+1,5000,123
+2,20000,456
+```
+
+## Running
+```bash
+python pipeline.py
+```
+You'll be prompted for the path to a CSV file containing your transaction data.

--- a/ai_automation/bank/pipeline.py
+++ b/ai_automation/bank/pipeline.py
@@ -1,0 +1,37 @@
+"""Bank transaction analysis pipeline demonstration."""
+
+import csv
+from typing import List, Dict
+
+def ingest_data(path: str) -> List[Dict[str, str]]:
+    """Load transactions from a CSV file."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+def analyze_data(transactions: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Flag large transactions as potential fraud."""
+    flagged = []
+    for t in transactions:
+        amount = float(t.get("amount", 0))
+        if amount > 10000:
+            flagged.append(t)
+    return flagged
+
+def process_data(flagged: List[Dict[str, str]]) -> List[str]:
+    """Format flagged transactions for reporting."""
+    return [f"Potential fraud: id={t.get('id')} amount=${t.get('amount')}" for t in flagged]
+
+def output_results(reports: List[str]) -> None:
+    for line in reports:
+        print(line)
+
+def main() -> None:
+    path = input("Path to transactions CSV: ")
+    transactions = ingest_data(path)
+    flagged = analyze_data(transactions)
+    reports = process_data(flagged)
+    output_results(reports)
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/pet_store/README.md
+++ b/ai_automation/pet_store/README.md
@@ -1,0 +1,16 @@
+---
+---
+
+# 🐾 Pet Store AI Pipeline Example
+
+The pet store demo shows how adoption records can flow through a simple pipeline. The script `pipeline.py` accepts adoption data as JSON objects typed into the console. It identifies any animals under one year old that need a first vet visit and prints reminders.
+
+## Running
+```bash
+python pipeline.py
+```
+Provide JSON objects like:
+```json
+{"name": "Fluffy", "species": "cat", "age": 0.5}
+```
+Finish with a blank line to see the generated messages.

--- a/ai_automation/pet_store/pipeline.py
+++ b/ai_automation/pet_store/pipeline.py
@@ -1,0 +1,41 @@
+"""Pet store adoption pipeline demonstration."""
+
+import json
+from typing import List, Dict
+
+def ingest_data() -> List[Dict[str, str]]:
+    """Collect adoption records as JSON lines from the user."""
+    print("Enter adoption records as JSON (blank line to finish):")
+    records = []
+    while True:
+        line = input()
+        if not line:
+            break
+        records.append(json.loads(line))
+    return records
+
+def analyze_data(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Find young animals needing vet checks."""
+    return [r for r in records if r.get("age", 0) < 1]
+
+def process_data(needs_check: List[Dict[str, str]]) -> List[str]:
+    """Create follow‑up messages."""
+    messages = []
+    for pet in needs_check:
+        name = pet.get("name", "Unknown")
+        species = pet.get("species", "pet")
+        messages.append(f"Schedule first vet visit for {name} the {species}.")
+    return messages
+
+def output_results(messages: List[str]) -> None:
+    for msg in messages:
+        print(msg)
+
+def main() -> None:
+    records = ingest_data()
+    needs_check = analyze_data(records)
+    messages = process_data(needs_check)
+    output_results(messages)
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/restaurant/README.md
+++ b/ai_automation/restaurant/README.md
@@ -1,0 +1,12 @@
+---
+---
+
+# 🍽️ Restaurant AI Pipeline Example
+
+This folder contains a small demonstration of how AI concepts can be used in a restaurant setting. The script `pipeline.py` ingests customer reviews from the console, performs a simple keyword‑based sentiment analysis, processes the score into a short summary, and prints the result.
+
+## Running
+```bash
+python pipeline.py
+```
+Enter several review lines and press **Enter** on a blank line to finish. The program will output whether the overall sentiment is positive, negative, or neutral.

--- a/ai_automation/restaurant/pipeline.py
+++ b/ai_automation/restaurant/pipeline.py
@@ -1,0 +1,49 @@
+"""Restaurant AI pipeline demonstration."""
+
+import re
+from typing import List
+
+def ingest_data() -> List[str]:
+    """Collect review lines from the user."""
+    print("Enter reviews (blank line to finish):")
+    reviews = []
+    while True:
+        line = input()
+        if not line:
+            break
+        reviews.append(line)
+    return reviews
+
+def analyze_data(reviews: List[str]) -> float:
+    """Simple keyword sentiment score."""
+    positive = {"good", "great", "amazing", "excellent", "love"}
+    negative = {"bad", "terrible", "awful", "hate", "poor"}
+    score = 0
+    for review in reviews:
+        tokens = re.findall(r"\w+", review.lower())
+        for token in tokens:
+            if token in positive:
+                score += 1
+            elif token in negative:
+                score -= 1
+    return score / len(reviews) if reviews else 0.0
+
+def process_data(score: float) -> str:
+    """Turn numeric score into a text summary."""
+    if score > 0:
+        return "Positive overall sentiment"
+    if score < 0:
+        return "Negative overall sentiment"
+    return "Neutral sentiment"
+
+def output_results(summary: str) -> None:
+    print(f"Summary: {summary}")
+
+def main() -> None:
+    reviews = ingest_data()
+    score = analyze_data(reviews)
+    summary = process_data(score)
+    output_results(summary)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ai_automation` folder with example pipelines
- implement restaurant, bank, pet store, and accounting firm demos
- document each demo with a README

## Testing
- `python -m py_compile ai_automation/*/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0d4045f48327b1dedd9a3cf53cb2