### PR TITLE
Add retail image classification package

### DIFF
--- a/ai_automation/retail_image_classification/README.md
+++ b/ai_automation/retail_image_classification/README.md
@@ -1,0 +1,63 @@
+# Retail Image Classification
+
+This package demonstrates how to enrich a folder of product images with labels
+from AWS Rekognition and store the results in a SQLite database.
+
+## Directory Layout
+
+```
+retail_image_classification/
+├── retail_image_classification/  # Python package
+│   ├── __init__.py
+│   ├── db.py                # Database helpers
+│   └── processor.py         # Image processing logic
+├── scripts/
+│   ├── classify_images.py   # Build or update the database
+│   └── query_labels.py      # Query images by label
+└── requirements.txt
+```
+
+The database `labels.db` (default name) contains a single table `image_labels`
+with columns:
+- `filename` – image file name
+- `label` – detected label
+- `confidence` – confidence score returned by Rekognition
+
+## Processing Images
+
+The script `classify_images.py` scans a folder, sends each image to AWS
+Rekognition and transforms the response into a DataFrame with columns
+`filename`, `label`, `confidence`. Records below the specified confidence
+threshold are dropped. The remaining data is appended to the SQLite database.
+
+Adjust the confidence filter using the `--min_confidence` option when running
+the script.
+
+Example:
+
+```bash
+python scripts/classify_images.py /path/to/images --db labels.db --min_confidence 80
+```
+
+## Querying the Database
+
+Use `query_labels.py` to list all images that contain a given label above a
+confidence threshold (90% by default).
+
+```bash
+python scripts/query_labels.py "Shoe" --min_confidence 90 --db labels.db
+```
+
+Example output:
+
+```
+product1.jpg (95.2%)
+product2.jpg (91.7%)
+```
+
+## Notes
+
+- AWS credentials must be configured for `boto3` (environment variables or AWS
+  config files).
+- The scripts can be run independently; `classify_images.py` must be executed
+  before querying so the database is populated.

--- a/ai_automation/retail_image_classification/requirements.txt
+++ b/ai_automation/retail_image_classification/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+pandas

--- a/ai_automation/retail_image_classification/retail_image_classification/__init__.py
+++ b/ai_automation/retail_image_classification/retail_image_classification/__init__.py
@@ -1,0 +1,3 @@
+"""Retail Image Classification package."""
+
+__all__ = ["processor", "db"]

--- a/ai_automation/retail_image_classification/retail_image_classification/db.py
+++ b/ai_automation/retail_image_classification/retail_image_classification/db.py
@@ -1,0 +1,40 @@
+import sqlite3
+import pandas as pd
+from pathlib import Path
+from typing import Iterable, Any
+
+
+def init_db(db_path: Path) -> None:
+    """Initialize the SQLite database with the required table."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS image_labels (
+            filename TEXT,
+            label TEXT,
+            confidence REAL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_labels(df: pd.DataFrame, db_path: Path) -> None:
+    """Save DataFrame records to the database."""
+    conn = sqlite3.connect(db_path)
+    df.to_sql("image_labels", conn, if_exists="append", index=False)
+    conn.close()
+
+
+def query_labels(label: str, min_confidence: float, db_path: Path) -> Iterable[sqlite3.Row]:
+    """Query images that match the label and confidence threshold."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.execute(
+        "SELECT filename, label, confidence FROM image_labels WHERE label = ? AND confidence >= ?",
+        (label, min_confidence),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows

--- a/ai_automation/retail_image_classification/retail_image_classification/processor.py
+++ b/ai_automation/retail_image_classification/retail_image_classification/processor.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from typing import List, Dict
+
+import boto3
+import pandas as pd
+
+from .db import init_db, save_labels
+
+
+def detect_labels(image_path: Path, client, max_labels: int = 10) -> List[Dict]:
+    """Call AWS Rekognition to detect labels for a given image."""
+    with image_path.open("rb") as f:
+        img_bytes = f.read()
+
+    response = client.detect_labels(Image={"Bytes": img_bytes}, MaxLabels=max_labels)
+    records = []
+    for label in response.get("Labels", []):
+        records.append({
+            "filename": image_path.name,
+            "label": label["Name"],
+            "confidence": label["Confidence"],
+        })
+    return records
+
+
+def process_folder(folder: Path, db_path: Path, confidence_threshold: float = 50.0) -> pd.DataFrame:
+    """Process all images in a folder and store results in a SQLite database."""
+    init_db(db_path)
+    client = boto3.client("rekognition")
+    all_records: List[Dict] = []
+
+    for img_file in folder.iterdir():
+        if img_file.is_file():
+            for rec in detect_labels(img_file, client):
+                if rec["confidence"] >= confidence_threshold:
+                    all_records.append(rec)
+
+    df = pd.DataFrame(all_records)
+    if not df.empty:
+        save_labels(df, db_path)
+    return df

--- a/ai_automation/retail_image_classification/scripts/classify_images.py
+++ b/ai_automation/retail_image_classification/scripts/classify_images.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Process a folder of images and store label metadata in a SQLite database."""
+
+import argparse
+from pathlib import Path
+
+from retail_image_classification.processor import process_folder
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Classify product images with AWS Rekognition")
+    parser.add_argument("image_folder", type=Path, help="Folder containing product images")
+    parser.add_argument("--db", type=Path, default=Path("labels.db"), help="SQLite database path")
+    parser.add_argument("--min_confidence", type=float, default=50.0, help="Minimum confidence to store")
+    args = parser.parse_args()
+
+    df = process_folder(args.image_folder, args.db, args.min_confidence)
+    if df.empty:
+        print("No labels detected above the threshold")
+    else:
+        print(df)
+        print(f"Saved {len(df)} records to {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/retail_image_classification/scripts/query_labels.py
+++ b/ai_automation/retail_image_classification/scripts/query_labels.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Query images by label and confidence."""
+
+import argparse
+from pathlib import Path
+
+from retail_image_classification.db import query_labels
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query labeled images")
+    parser.add_argument("label", help="Label to search for")
+    parser.add_argument("--min_confidence", type=float, default=90.0, help="Minimum confidence")
+    parser.add_argument("--db", type=Path, default=Path("labels.db"), help="SQLite database path")
+    args = parser.parse_args()
+
+    rows = query_labels(args.label, args.min_confidence, args.db)
+    if not rows:
+        print("No matching images found")
+    else:
+        for row in rows:
+            print(f"{row['filename']} ({row['confidence']:.2f}%)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add retail image classification example with AWS Rekognition
- store labels in SQLite and provide CLI for queries
- document how to build the DB and run the CLI

## Testing
- `python -m py_compile ai_automation/retail_image_classification/retail_image_classification/*.py ai_automation/retail_image_classification/scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0dcce7348327a7aa426ca1ee6109