### PR TITLE
Add collaborative filtering FastAPI example

### DIFF
--- a/ai_automation/recommendation_engine/README.md
+++ b/ai_automation/recommendation_engine/README.md
@@ -1,0 +1,26 @@
+# Recommendation Engine
+
+This folder contains a minimal example of building a collaborative filtering recommendation engine and exposing it through a FastAPI service.
+
+## Data Wrangling
+
+The service expects a CSV file with `user_id`, `product_id` and `rating` columns. The data is loaded into a pandas `DataFrame` and transformed into the internal format expected by the `surprise` library. Ratings are converted into a user–item matrix using pandas and SciPy's sparse structures under the hood when `surprise` builds the training set.
+
+## Recommendation Algorithm
+
+A matrix factorization model (Surprise's `SVD`) is trained on the full interaction dataset. For a requested user, the model scores every product the user has not rated and returns the top results with the highest predicted rating.
+
+## Running the Server
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Prepare `user_product_interactions.csv` in this folder (or provide a path via the `/train` endpoint).
+3. Start the API server:
+   ```bash
+   uvicorn app:app --reload
+   ```
+4. Endpoints:
+   - `POST /train` – Body `{ "csv_path": "optional/path.csv" }` retrains the model on the given CSV.
+   - `GET /recommend/{user_id}` – Returns the top‑10 `product_id` values recommended for that user.

--- a/ai_automation/recommendation_engine/app.py
+++ b/ai_automation/recommendation_engine/app.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from model import RecommendationModel
+
+CSV_PATH = "user_product_interactions.csv"
+
+app = FastAPI()
+model = RecommendationModel(CSV_PATH)
+
+
+class TrainRequest(BaseModel):
+    csv_path: str | None = None
+
+
+@app.post("/train")
+def train(data: TrainRequest):
+    if data.csv_path:
+        model.csv_path = data.csv_path
+    try:
+        model.train()
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return {"status": "trained"}
+
+
+@app.get("/recommend/{user_id}")
+def recommend(user_id: str):
+    try:
+        recs = model.recommend(user_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"user_id": user_id, "product_ids": recs}

--- a/ai_automation/recommendation_engine/model.py
+++ b/ai_automation/recommendation_engine/model.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from surprise import Dataset, Reader, SVD
+
+
+class RecommendationModel:
+    """Simple wrapper around Surprise's SVD algorithm."""
+
+    def __init__(self, csv_path: str):
+        self.csv_path = csv_path
+        self.df: pd.DataFrame | None = None
+        self.model: SVD | None = None
+
+    def load_data(self) -> pd.DataFrame:
+        self.df = pd.read_csv(self.csv_path)
+        return self.df
+
+    def train(self) -> None:
+        self.load_data()
+        if self.df is None:
+            raise ValueError("No data loaded")
+        rating_scale = (self.df.rating.min(), self.df.rating.max())
+        reader = Reader(rating_scale=rating_scale)
+        data = Dataset.load_from_df(
+            self.df[["user_id", "product_id", "rating"]], reader
+        )
+        trainset = data.build_full_trainset()
+        self.model = SVD()
+        self.model.fit(trainset)
+
+    def recommend(self, user_id: str, n: int = 10) -> list[str]:
+        if self.model is None or self.df is None:
+            raise ValueError("Model has not been trained")
+        all_items = self.df["product_id"].unique()
+        rated = self.df[self.df["user_id"] == user_id]["product_id"].unique()
+        candidates = [iid for iid in all_items if iid not in rated]
+        scored = [
+            (iid, self.model.predict(str(user_id), str(iid)).est) for iid in candidates
+        ]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [iid for iid, _ in scored[:n]]

--- a/ai_automation/recommendation_engine/requirements.txt
+++ b/ai_automation/recommendation_engine/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pandas
+scipy
+scikit-surprise


### PR DESCRIPTION
## Summary
- add `recommendation_engine` folder under `ai_automation`
- implement `model.py` using `scikit-surprise` SVD
- expose FastAPI app with `/train` and `/recommend` endpoints
- document usage and algorithm in README
- include minimal requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0dd410c883278855c3cfc509995e