### PR TITLE
Add invoice OCR scanner

### DIFF
--- a/ai_automation/invoice_ocr_scanner/README.md
+++ b/ai_automation/invoice_ocr_scanner/README.md
@@ -1,0 +1,45 @@
+# Invoice OCR Scanner
+
+This module processes scanned invoice PDFs or JPEGs and extracts
+structured data using Tesseract OCR. Parsed results are saved to CSV
+and inserted into a SQLite database.
+
+## How OCR Works
+
+OCR (Optical Character Recognition) engines like Tesseract analyze
+images of text and convert the shapes of the characters into actual
+text data. Tesseract applies image preprocessing and pattern matching
+to recognize individual letters. When given a PDF, pages are converted
+into images before running OCR. The output is a block of raw text that
+represents all text detected on the invoice.
+
+## Parsing Rules
+
+The parser searches the OCR text with simple regular expressions:
+
+- **Invoice number** – the first match of `Invoice` followed by an ID.
+- **Date** – a string formatted like `MM/DD/YYYY` or `MM-DD-YYYY`.
+- **Vendor** – text following the word `Vendor` on its line.
+- **Total** – the amount following the word `Total`, with or without a
+  dollar sign.
+
+These rules are intentionally basic and may need to be customized for
+different invoice layouts.
+
+## Running the Scanner
+
+1. Install Python packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Put invoice PDFs or JPEGs in a directory, e.g. `invoices/`.
+3. Run the script:
+   ```bash
+   python main.py invoices/ --csv results.csv --db invoices.db
+   ```
+4. Inspect `results.csv` for the extracted data. The same rows are also
+   appended to the `invoices` table inside `invoices.db`.
+
+You can rerun the script on new invoice batches by pointing to a
+different directory or file list. Review the CSV output to verify that
+the parsing rules captured the fields correctly.

--- a/ai_automation/invoice_ocr_scanner/main.py
+++ b/ai_automation/invoice_ocr_scanner/main.py
@@ -1,0 +1,84 @@
+import argparse
+import os
+import re
+import sqlite3
+
+import pytesseract
+from PIL import Image
+from pdf2image import convert_from_path
+import pandas as pd
+
+
+INVOICE_NO_RE = re.compile(r"Invoice\s*#?:?\s*(?P<number>\S+)", re.IGNORECASE)
+DATE_RE = re.compile(r"Date\s*:?\s*(?P<date>\d{1,2}[/-]\d{1,2}[/-]\d{2,4})", re.IGNORECASE)
+VENDOR_RE = re.compile(r"Vendor\s*:?\s*(?P<vendor>.+)", re.IGNORECASE)
+TOTAL_RE = re.compile(r"Total\s*:?\s*\$?(?P<total>[0-9,\.]+)", re.IGNORECASE)
+
+
+def extract_text(file_path: str) -> str:
+    """Extract text from an image or PDF using Tesseract."""
+    if file_path.lower().endswith(".pdf"):
+        images = convert_from_path(file_path)
+        text_parts = [pytesseract.image_to_string(img) for img in images]
+        return "\n".join(text_parts)
+    else:
+        with Image.open(file_path) as img:
+            return pytesseract.image_to_string(img)
+
+
+def parse_invoice(text: str) -> dict:
+    """Parse invoice fields using simple regular expressions."""
+    invoice = {
+        "invoice_number": None,
+        "date": None,
+        "vendor": None,
+        "total": None,
+    }
+
+    if m := INVOICE_NO_RE.search(text):
+        invoice["invoice_number"] = m.group("number")
+    if m := DATE_RE.search(text):
+        invoice["date"] = m.group("date")
+    if m := VENDOR_RE.search(text):
+        invoice["vendor"] = m.group("vendor").strip()
+    if m := TOTAL_RE.search(text):
+        invoice["total"] = m.group("total")
+
+    return invoice
+
+
+def process_directory(input_dir: str) -> pd.DataFrame:
+    """Scan a directory for invoices and return a DataFrame."""
+    records = []
+    for fname in os.listdir(input_dir):
+        if not fname.lower().endswith((".pdf", ".jpg", ".jpeg")):
+            continue
+        path = os.path.join(input_dir, fname)
+        text = extract_text(path)
+        data = parse_invoice(text)
+        data["filename"] = fname
+        records.append(data)
+    return pd.DataFrame(records)
+
+
+def export_results(df: pd.DataFrame, csv_path: str, db_path: str) -> None:
+    df.to_csv(csv_path, index=False)
+    conn = sqlite3.connect(db_path)
+    df.to_sql("invoices", conn, if_exists="append", index=False)
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Invoice OCR scanner")
+    parser.add_argument("input_dir", help="Directory containing invoice PDFs or images")
+    parser.add_argument("--csv", default="invoices.csv", help="Output CSV file")
+    parser.add_argument("--db", default="invoices.db", help="SQLite database file")
+    args = parser.parse_args()
+
+    df = process_directory(args.input_dir)
+    export_results(df, args.csv, args.db)
+    print(f"Processed {len(df)} invoices. Results saved to {args.csv} and {args.db}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/invoice_ocr_scanner/requirements.txt
+++ b/ai_automation/invoice_ocr_scanner/requirements.txt
@@ -1,0 +1,5 @@
+pytesseract
+Pillow
+pandas
+sqlite3
+pdf2image


### PR DESCRIPTION
## Summary
- add invoice_ocr_scanner module under `ai_automation`
- provide a `main.py` to process invoice images/PDFs with Tesseract OCR
- document usage and parsing rules in README
- specify dependencies in `requirements.txt`

## Testing
- `python -m py_compile ai_automation/invoice_ocr_scanner/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684a0dfa46d08327bc38dfdecf977140