### PR TITLE
Add churn prediction example

### DIFF
--- a/ai_automation/churn_prediction/README.md
+++ b/ai_automation/churn_prediction/README.md
@@ -1,0 +1,35 @@
+# Churn Prediction Pipeline
+
+This example demonstrates a simple machine learning pipeline to predict whether a customer will churn.
+
+## Files
+
+- `train.py` – trains a `RandomForestClassifier` on historical customer data.
+- `predict.py` – loads a saved model and scores new customers.
+- `requirements.txt` – Python dependencies.
+
+## Data Wrangling & Feature Engineering
+
+The training CSV should contain columns like `user_id`, `tenure`, `usage_metrics`, `support_calls`, and `churn_flag`.
+The script drops the `user_id` column, one‑hot encodes any categorical features, and standardizes numerical values. The processed features are fed into the classifier.
+
+## Model Selection
+
+A RandomForest classifier was chosen because it handles mixed data types well and requires little tuning to achieve good baseline performance.
+
+## Training & Evaluation
+
+```bash
+pip install -r requirements.txt
+python train.py path/to/customers.csv model.joblib
+```
+
+The script splits the data into train and test sets, fits the model, and prints accuracy, ROC‑AUC, and a classification report. The trained pipeline is saved with `joblib`.
+
+## Scoring New Data
+
+```bash
+python predict.py model.joblib new_customers.csv predictions.csv
+```
+
+`predict.py` outputs a CSV with the predicted label and probability for each new customer.

--- a/ai_automation/churn_prediction/predict.py
+++ b/ai_automation/churn_prediction/predict.py
@@ -1,0 +1,38 @@
+import argparse
+import joblib
+import pandas as pd
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Score new customer data")
+    parser.add_argument("model", help="Path to saved model")
+    parser.add_argument("input_csv", help="CSV with customer features")
+    parser.add_argument(
+        "output_csv",
+        nargs="?",
+        default="scores.csv",
+        help="Where to save predictions",
+    )
+    args = parser.parse_args()
+
+    model = joblib.load(args.model)
+    df = pd.read_csv(args.input_csv)
+    user_ids = df.get("user_id")
+    X = df.drop(columns=["user_id"], errors="ignore")
+
+    preds = model.predict(X)
+    probs = model.predict_proba(X)[:, 1]
+
+    results = pd.DataFrame(
+        {
+            "user_id": user_ids,
+            "churn_prediction": preds,
+            "churn_probability": probs,
+        }
+    )
+    results.to_csv(args.output_csv, index=False)
+    print(f"Predictions saved to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/churn_prediction/requirements.txt
+++ b/ai_automation/churn_prediction/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+scikit-learn
+joblib

--- a/ai_automation/churn_prediction/train.py
+++ b/ai_automation/churn_prediction/train.py
@@ -1,0 +1,68 @@
+import argparse
+import joblib
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.pipeline import Pipeline
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score, roc_auc_score, classification_report
+
+
+def load_data(csv_path: str):
+    """Load customer activity CSV."""
+    return pd.read_csv(csv_path)
+
+
+def build_pipeline(df: pd.DataFrame):
+    """Create preprocessing and modeling pipeline."""
+    X = df.drop(columns=["churn_flag", "user_id"], errors="ignore")
+    y = df["churn_flag"]
+
+    categorical_cols = X.select_dtypes(include=["object", "category"]).columns
+    numeric_cols = X.select_dtypes(include=["number"]).columns
+
+    preprocessor = ColumnTransformer([
+        ("categorical", OneHotEncoder(handle_unknown="ignore"), categorical_cols),
+        ("numeric", StandardScaler(), numeric_cols),
+    ])
+
+    clf = RandomForestClassifier(random_state=42)
+    pipeline = Pipeline([
+        ("preprocessor", preprocessor),
+        ("classifier", clf),
+    ])
+    return pipeline, X, y
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train churn prediction model")
+    parser.add_argument("csv", help="Path to training CSV file")
+    parser.add_argument("model_output", help="Path to save the trained model")
+    args = parser.parse_args()
+
+    df = load_data(args.csv)
+    pipeline, X, y = build_pipeline(df)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+
+    pipeline.fit(X_train, y_train)
+
+    preds = pipeline.predict(X_test)
+    probs = pipeline.predict_proba(X_test)[:, 1]
+
+    accuracy = accuracy_score(y_test, preds)
+    roc_auc = roc_auc_score(y_test, probs)
+
+    print(f"Accuracy: {accuracy:.4f}")
+    print(f"ROC-AUC: {roc_auc:.4f}")
+    print(classification_report(y_test, preds))
+
+    joblib.dump(pipeline, args.model_output)
+    print(f"Model saved to {args.model_output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add churn prediction pipeline in `ai_automation`
- implement `train.py` and `predict.py`
- describe usage and workflow in README
- list python dependencies

## Testing
- `python -m py_compile ai_automation/churn_prediction/train.py ai_automation/churn_prediction/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0e04e66883279b9a58e34c1563c7