### PR TITLE
Add K-Means customer segmentation example

### DIFF
--- a/ai_automation/customer_segmentation/README.md
+++ b/ai_automation/customer_segmentation/README.md
@@ -1,0 +1,23 @@
+# Customer Segmentation with K-Means
+
+This example groups customers based on their transaction history. Clustering lets you discover natural segments in the data without labels.
+
+## Why clustering?
+- Segments reveal patterns in spending, purchase frequency and recency.
+- Targeted marketing is easier when customers are grouped by behavior.
+
+## Interpreting clusters
+- Each cluster centroid represents the average customer in that group.
+- Higher or lower values in the centroid show how that segment differs from the overall population.
+
+## Usage
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the script with your transaction CSV:
+   ```bash
+   python segment.py transactions.csv
+   ```
+   This creates `segment_profiles.csv` and `segments_scatter.png` in the current directory.
+3. Open `segment_profiles.csv` to view average spend, frequency and recency for each segment. The scatter plot visualizes two dimensions colored by segment.

--- a/ai_automation/customer_segmentation/requirements.txt
+++ b/ai_automation/customer_segmentation/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+scikit-learn
+matplotlib

--- a/ai_automation/customer_segmentation/segment.py
+++ b/ai_automation/customer_segmentation/segment.py
@@ -1,0 +1,36 @@
+import sys
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from sklearn.cluster import KMeans
+import matplotlib.pyplot as plt
+
+# Simple pipeline for customer segmentation using K-Means.
+
+if len(sys.argv) < 2:
+    print("Usage: python segment.py <transactions_csv>")
+    sys.exit(1)
+
+csv_path = sys.argv[1]
+
+df = pd.read_csv(csv_path)
+
+features = df[["total_spent", "frequency", "recency"]]
+scaler = StandardScaler()
+scaled = scaler.fit_transform(features)
+
+kmeans = KMeans(n_clusters=4, random_state=0)
+labels = kmeans.fit_predict(scaled)
+
+df["segment"] = labels
+
+profiles = df.groupby("segment")[["total_spent", "frequency", "recency"]].mean()
+profiles.to_csv("segment_profiles.csv")
+
+plt.figure(figsize=(8, 6))
+scatter = plt.scatter(df["total_spent"], df["recency"], c=df["segment"], cmap="viridis")
+plt.xlabel("Total Spent")
+plt.ylabel("Recency")
+plt.title("Customer Segments")
+plt.colorbar(scatter, label="Segment")
+plt.tight_layout()
+plt.savefig("segments_scatter.png")


### PR DESCRIPTION
## Summary
- add a new `customer_segmentation` automation example
- implement `segment.py` for a simple clustering pipeline
- document usage and explanation in README
- list required libraries

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a0e0a7f6883278f6fe6bb2e95c0de