### PR TITLE
Add sales forecasting example

### DIFF
--- a/ai_automation/sales_forecasting/README.md
+++ b/ai_automation/sales_forecasting/README.md
@@ -1,0 +1,47 @@
+# Sales Forecasting Example
+
+This folder contains a minimal example of forecasting daily sales using Python.
+The example demonstrates how to transform raw sales data, train a forecasting
+model, and visualize the results.
+
+## Files
+
+- `forecast.py` – Reads a CSV of historical daily sales and forecasts the next
+  30 days using Prophet.
+- `requirements.txt` – Python dependencies required to run the example.
+
+## Time-Series Decomposition
+
+Time-series data can be viewed as a combination of **trend**, **seasonality** and
+**residual** components. Trend describes long‑term movement, seasonality captures
+repeating patterns such as day‑of‑week effects, and residual represents random
+noise. Prophet automatically models these pieces which makes it convenient for
+business data like daily sales.
+
+## Model Selection and Hyperparameter Tuning
+
+The script uses Facebook's Prophet library, which generally performs well on
+daily business metrics. Prophet supports parameters such as `seasonality_mode`
+(additive vs. multiplicative) and `changepoint_prior_scale` that control how the
+trend adapts to changes. These can be tuned by fitting the model with different
+values and evaluating hold‑out performance (MAE/MAPE in this example).
+
+You can also experiment with ARIMA models from the `statsmodels` library by
+modifying `forecast.py` if Prophet does not provide satisfactory accuracy.
+
+## Running the Forecast
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Prepare a CSV file containing columns `date`, `store_id`, and `sales`.
+3. Run the script:
+   ```bash
+   python forecast.py path/to/sales.csv --store-id 1 --plot forecast.png
+   ```
+   The program prints MAE and MAPE for the last 30 days and saves a plot showing
+   historical sales together with the 30‑day forecast.
+
+The resulting chart helps you visually compare actual sales to the predicted
+values and understand future expectations.

--- a/ai_automation/sales_forecasting/forecast.py
+++ b/ai_automation/sales_forecasting/forecast.py
@@ -1,0 +1,82 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+from prophet import Prophet
+import matplotlib.pyplot as plt
+
+
+def load_data(csv_path: Path, store_id: int | None = None) -> pd.DataFrame:
+    df = pd.read_csv(csv_path)
+    df['date'] = pd.to_datetime(df['date'])
+    if store_id is not None:
+        df = df[df['store_id'] == store_id]
+    df = df.sort_values('date')
+    df['day_of_week'] = df['date'].dt.dayofweek
+    df['month'] = df['date'].dt.month
+    return df
+
+
+def train_test_split(df: pd.DataFrame, holdout_days: int = 30):
+    train = df.iloc[:-holdout_days]
+    holdout = df.iloc[-holdout_days:]
+    return train, holdout
+
+
+def train_prophet(train: pd.DataFrame) -> Prophet:
+    model = Prophet()
+    model.add_regressor('day_of_week')
+    model.add_regressor('month')
+    model.fit(train.rename(columns={'date': 'ds', 'sales': 'y'}))
+    return model
+
+
+def forecast(model: Prophet, df: pd.DataFrame, periods: int = 30) -> pd.DataFrame:
+    future = model.make_future_dataframe(periods=periods)
+    future['day_of_week'] = future['ds'].dt.dayofweek
+    future['month'] = future['ds'].dt.month
+    forecast = model.predict(future)
+    return forecast
+
+
+def evaluate(holdout: pd.DataFrame, forecast_df: pd.DataFrame) -> tuple[float, float]:
+    merged = holdout.merge(forecast_df[['ds', 'yhat']], left_on='date', right_on='ds')
+    errors = (merged['sales'] - merged['yhat']).abs()
+    mae = errors.mean()
+    mape = (errors / merged['sales']).mean() * 100
+    return mae, mape
+
+
+def plot_forecast(df: pd.DataFrame, forecast_df: pd.DataFrame, output: Path | None = None):
+    plt.figure(figsize=(10, 6))
+    plt.plot(df['date'], df['sales'], label='Historical')
+    plt.plot(forecast_df['ds'], forecast_df['yhat'], label='Forecast')
+    plt.xlabel('Date')
+    plt.ylabel('Sales')
+    plt.legend()
+    if output:
+        plt.savefig(output)
+    else:
+        plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Forecast sales for the next 30 days")
+    parser.add_argument('csv', type=Path, help='Path to sales CSV')
+    parser.add_argument('--store-id', type=int, help='Store ID to filter')
+    parser.add_argument('--plot', type=Path, help='Path to save the plot (PNG)')
+    args = parser.parse_args()
+
+    df = load_data(args.csv, args.store_id)
+    train, holdout = train_test_split(df)
+    model = train_prophet(train)
+    forecast_df = forecast(model, df, periods=30)
+
+    mae, mape = evaluate(holdout, forecast_df)
+    print(f"MAE: {mae:.2f}")
+    print(f"MAPE: {mape:.2f}%")
+
+    plot_forecast(df, forecast_df, args.plot)
+
+
+if __name__ == '__main__':
+    main()

--- a/ai_automation/sales_forecasting/requirements.txt
+++ b/ai_automation/sales_forecasting/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+prophet
+matplotlib


### PR DESCRIPTION
## Summary
- add `sales_forecasting` package under `ai_automation`
- implement `forecast.py` using Prophet
- document time-series concepts and usage in README
- specify required packages

## Testing
- `python -m py_compile ai_automation/sales_forecasting/forecast.py`
- `python ai_automation/sales_forecasting/forecast.py /tmp/sample_sales.csv --store-id 1 --plot /tmp/output.png` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a0e0fd3ac83279feeaf999e1f9ad0