### PR TITLE
Add Airflow ETL example

### DIFF
--- a/ai_automation/airflow_etl/README.md
+++ b/ai_automation/airflow_etl/README.md
@@ -1,0 +1,30 @@
+# 🚀 Airflow ETL Example
+
+This folder contains a minimal ETL pipeline using Apache Airflow. The DAG extracts
+JSON from a REST API, converts the data to Parquet with pandas, and loads it into
+a PostgreSQL data warehouse. Slack notifications report success or failure.
+
+## DAG Overview
+- **Schedule**: Daily at midnight (`0 0 * * *`)
+- **Tasks**:
+  1. `extract` – call the REST API and save the response as JSON
+  2. `transform` – validate and cast the JSON then write a Parquet file
+  3. `load` – load the Parquet data into PostgreSQL
+  4. `notify` – send a Slack message summarizing the run
+
+## Airflow Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create connections in the Airflow UI:
+   - **postgres_default** – connection string to the data warehouse
+   - **slack_default** – Slack API token
+3. Define the following Airflow Variables (or env vars):
+   - `API_ENDPOINT` – URL for the REST API
+
+## Monitoring & Troubleshooting
+- Use the Airflow web UI to monitor DAG runs and task logs.
+- Failed tasks trigger a Slack notification detailing the error.
+- Check the logs for connectivity issues (API or database) or data validation
+  errors during the transform step.

--- a/ai_automation/airflow_etl/dags/etl_dag.py
+++ b/ai_automation/airflow_etl/dags/etl_dag.py
@@ -1,0 +1,83 @@
+"""Simple Airflow ETL example."""
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from datetime import datetime
+
+import pandas as pd
+import sqlalchemy
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+from slack_sdk import WebClient
+
+
+def send_slack_message(message: str) -> None:
+    """Send a message to Slack using the token stored in Airflow Variables."""
+    token = Variable.get("SLACK_TOKEN")
+    channel = Variable.get("SLACK_CHANNEL", "#general")
+    try:
+        WebClient(token=token).chat_postMessage(channel=channel, text=message)
+    except Exception as exc:  # pragma: no cover - notification failures shouldn't break the DAG
+        logging.error("Failed to send Slack message: %s", exc)
+
+
+def extract(**context) -> str:
+    endpoint = Variable.get("API_ENDPOINT")
+    logging.info("Requesting data from %s", endpoint)
+    with urllib.request.urlopen(endpoint) as response:
+        data = json.loads(response.read())
+    path = "/tmp/api_data.json"
+    with open(path, "w") as f:
+        json.dump(data, f)
+    return path
+
+
+def transform(ti) -> str:
+    json_path = ti.xcom_pull(task_ids="extract")
+    with open(json_path) as f:
+        records = json.load(f)
+    df = pd.json_normalize(records)
+    # Cast numeric columns to floats for simplicity
+    for col in df.columns:
+        if df[col].dtype == object:
+            try:
+                df[col] = df[col].astype(float)
+            except ValueError:
+                pass
+    parquet_path = "/tmp/api_data.parquet"
+    df.to_parquet(parquet_path, index=False)
+    return parquet_path
+
+
+def load(ti) -> None:
+    parquet_path = ti.xcom_pull(task_ids="transform")
+    df = pd.read_parquet(parquet_path)
+    engine = sqlalchemy.create_engine(Variable.get("POSTGRES_URI"))
+    df.to_sql("api_data", engine, if_exists="append", index=False)
+    engine.dispose()
+
+
+def notify_success(context):
+    send_slack_message(f"DAG {context['dag'].dag_id} succeeded")
+
+
+def notify_failure(context):
+    send_slack_message(f"DAG {context['dag'].dag_id} failed: {context['exception']}")
+
+
+with DAG(
+    dag_id="example_etl_dag",
+    start_date=datetime(2024, 1, 1),
+    schedule_interval="0 0 * * *",
+    catchup=False,
+    on_failure_callback=notify_failure,
+    on_success_callback=notify_success,
+) as dag:
+    extract_task = PythonOperator(task_id="extract", python_callable=extract)
+    transform_task = PythonOperator(task_id="transform", python_callable=transform)
+    load_task = PythonOperator(task_id="load", python_callable=load)
+
+    extract_task >> transform_task >> load_task

--- a/ai_automation/airflow_etl/requirements.txt
+++ b/ai_automation/airflow_etl/requirements.txt
@@ -1,0 +1,4 @@
+apache-airflow
+pandas
+sqlalchemy
+slack-sdk


### PR DESCRIPTION
## Summary
- add Airflow ETL folder with requirements
- implement example DAG that extracts JSON, transforms to Parquet and loads to Postgres
- document DAG scheduling, configuration and monitoring guidance

## Testing
- `python -m py_compile ai_automation/airflow_etl/dags/etl_dag.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f30b9c48327b4f379952173106d