### PR TITLE
Add error handling logging pipeline example

### DIFF
--- a/ai_automation/error_handling_logging/README.md
+++ b/ai_automation/error_handling_logging/README.md
@@ -1,0 +1,30 @@
+# Error Handling and Logging Pipeline
+
+This example demonstrates a small data‑processing pipeline with robust error handling and logging. It reads input records from a CSV or JSON file, processes them, and saves the results. The package also supports optional Slack alerts on failures.
+
+## Logging configuration
+
+Logging is configured in `config.py`. A logger named `error_handling_logging` writes to both the console and a `TimedRotatingFileHandler` that rotates daily and keeps seven backups. Log messages include a timestamp, level, module name, and message.
+
+To change log levels or handlers, modify the configuration in `config.py`. The log file location is defined by `LOG_FILE` next to the module.
+
+## Custom exceptions
+
+`utils.py` defines a small hierarchy:
+
+- `PipelineError` – base class
+- `ValidationError` – raised when input fails validation or is missing
+- `APIError` – raised when saving output or calling external services fails
+- `ProcessingError` – raised inside `process.py` when a record cannot be processed
+
+These exceptions are caught in `main.py` and logged appropriately.
+
+## Running the pipeline
+
+Install requirements listed in `requirements.txt` and run:
+
+```bash
+python main.py path/to/input.csv -o output.json
+```
+
+Logs appear in the console and in `pipeline.log`. To enable Slack alerts on errors, set the environment variable `SLACK_WEBHOOK_URL` to a valid webhook URL.

--- a/ai_automation/error_handling_logging/config.py
+++ b/ai_automation/error_handling_logging/config.py
@@ -1,0 +1,28 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+LOG_FILE = Path(__file__).parent / 'pipeline.log'
+
+# Configure root logger
+logger = logging.getLogger('error_handling_logging')
+logger.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter(
+    fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+# Console handler
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.DEBUG)
+console_handler.setFormatter(formatter)
+
+# Rotating file handler (daily rotation, keep 7 days)
+file_handler = TimedRotatingFileHandler(LOG_FILE, when='D', interval=1, backupCount=7)
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(formatter)
+
+logger.addHandler(console_handler)
+logger.addHandler(file_handler)
+

--- a/ai_automation/error_handling_logging/main.py
+++ b/ai_automation/error_handling_logging/main.py
@@ -1,0 +1,84 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import pandas as pd
+import requests
+
+from .config import logger
+from .process import process_records
+from .utils import ValidationError, APIError, ProcessingError
+
+
+def read_input(path: Path) -> List[Dict[str, str]]:
+    try:
+        if not path.exists():
+            raise ValidationError(f"Input file {path} does not exist")
+        if path.suffix.lower() == '.csv':
+            df = pd.read_csv(path)
+            return df.to_dict(orient='records')
+        if path.suffix.lower() == '.json':
+            with path.open() as f:
+                return json.load(f)
+        raise ValidationError('Unsupported file type')
+    except Exception as exc:
+        raise ValidationError(str(exc)) from exc
+
+
+def save_output(path: Path, records: List[Dict[str, str]]) -> None:
+    try:
+        with path.open('w') as f:
+            json.dump(records, f, indent=2)
+    except Exception as exc:
+        raise APIError(str(exc)) from exc
+
+
+def send_alert(message: str) -> None:
+    webhook = os.environ.get('SLACK_WEBHOOK_URL')
+    if not webhook:
+        return
+    try:
+        requests.post(webhook, json={'text': message}, timeout=5)
+    except requests.RequestException as exc:
+        logger.warning('Failed to send alert: %s', exc)
+
+
+def main(input_path: str, output_path: str) -> None:
+    logger.info('Starting pipeline')
+    try:
+        records = read_input(Path(input_path))
+        logger.debug('Read %d records', len(records))
+    except ValidationError as exc:
+        logger.error('Validation error: %s', exc)
+        send_alert(f'Validation error: {exc}')
+        return
+
+    try:
+        processed = process_records(records)
+        logger.debug('Processed %d records', len(processed))
+    except ProcessingError as exc:
+        logger.error('Processing error: %s', exc)
+        send_alert(f'Processing error: {exc}')
+        return
+
+    try:
+        save_output(Path(output_path), processed)
+        logger.info('Saved output to %s', output_path)
+    except APIError as exc:
+        logger.error('Failed to save output: %s', exc)
+        send_alert(f'Output error: {exc}')
+        return
+
+    logger.info('Pipeline completed successfully')
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Run error handling pipeline')
+    parser.add_argument('input', help='Path to input CSV or JSON')
+    parser.add_argument('-o', '--output', default='output.json', help='Output JSON path')
+    args = parser.parse_args()
+
+    main(args.input, args.output)

--- a/ai_automation/error_handling_logging/process.py
+++ b/ai_automation/error_handling_logging/process.py
@@ -1,0 +1,16 @@
+from typing import List, Dict
+
+from .utils import ProcessingError
+
+
+def process_records(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Simple processing step that capitalizes a `name` field."""
+    processed = []
+    try:
+        for rec in records:
+            if 'name' not in rec:
+                raise ProcessingError("Missing 'name' field")
+            processed.append({'name': rec['name'].upper()})
+    except Exception as exc:
+        raise ProcessingError(str(exc)) from exc
+    return processed

--- a/ai_automation/error_handling_logging/requirements.txt
+++ b/ai_automation/error_handling_logging/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+pytest
+slack-sdk

--- a/ai_automation/error_handling_logging/tests/test_error_handling.py
+++ b/ai_automation/error_handling_logging/tests/test_error_handling.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from ..main import main, read_input, ValidationError
+
+
+def test_missing_file(tmp_path, caplog):
+    missing = tmp_path / 'nope.csv'
+    caplog.set_level('ERROR')
+    main(str(missing), str(tmp_path / 'out.json'))
+    assert any('Validation error' in r.message for r in caplog.records)
+
+
+def test_invalid_data(tmp_path):
+    bad = tmp_path / 'bad.csv'
+    bad.write_text('foo\n1')
+    with pytest.raises(ValidationError):
+        read_input(bad)
+
+
+def test_processing_error(tmp_path, caplog):
+    data = pd.DataFrame({'age': [1]})
+    csv_path = tmp_path / 'input.csv'
+    data.to_csv(csv_path, index=False)
+    caplog.set_level('ERROR')
+    main(str(csv_path), str(tmp_path / 'out.json'))
+    assert any('Processing error' in r.message for r in caplog.records)

--- a/ai_automation/error_handling_logging/utils.py
+++ b/ai_automation/error_handling_logging/utils.py
@@ -1,0 +1,11 @@
+class PipelineError(Exception):
+    """Base class for pipeline exceptions."""
+
+class ValidationError(PipelineError):
+    """Raised when input data fails validation."""
+
+class APIError(PipelineError):
+    """Raised when an external API call fails."""
+
+class ProcessingError(PipelineError):
+    """Raised when the processing step fails."""


### PR DESCRIPTION
## Summary
- add error_handling_logging example package with robust logging
- implement processing, logging config, custom exceptions
- provide tests showing error handling behaviour
- document how logging and custom exceptions work

## Testing
- `pytest -q ai_automation/error_handling_logging/tests/test_error_handling.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a0f384bf08327b3d0bb5bc27bafda