### PR TITLE
Add multi API enrichment example

### DIFF
--- a/ai_automation/multi_api_enrichment/README.md
+++ b/ai_automation/multi_api_enrichment/README.md
@@ -1,0 +1,28 @@
+# Multi-API Enrichment Example
+
+This folder demonstrates chaining several APIs to enrich product descriptions with marketing headlines, audio, and images.
+
+## Files
+
+- `enrich.py` – Asynchronously generates headlines with OpenAI and requests audio and images from remote APIs.
+- `async_utils.py` – Helper for running coroutines under a concurrency limit with simple retry backoff.
+- `requirements.txt` – Python dependencies.
+
+## Chaining API Outputs
+
+Each product's description feeds into OpenAI to create a headline. That headline then becomes the input text for both a text‑to‑speech API (Sora) and an image generation API (Midjourney). The headline itself is written to `enriched.csv` while the audio and image are stored under the `audio/` and `images/` directories.
+
+## Concurrency and Backoff
+
+The `async_utils.rate_limited_gather` function wraps `asyncio.gather` with a semaphore to limit in‑flight requests. When network calls fail, tasks wait for an exponentially increasing delay before retrying. This keeps the overall request rate under control while handling transient errors.
+
+## File Naming
+
+Output media files use the product ID so they are easy to match back to the source record:
+
+```
+audio/<product_id>.mp3
+images/<product_id>.png
+```
+
+The CSV `enriched.csv` will contain the original product columns plus a new `headline` column.

--- a/ai_automation/multi_api_enrichment/async_utils.py
+++ b/ai_automation/multi_api_enrichment/async_utils.py
@@ -1,0 +1,30 @@
+"""Asynchronous helpers for concurrency control."""
+
+import asyncio
+from typing import Awaitable, Iterable, List, TypeVar, Callable
+
+T = TypeVar("T")
+
+async def rate_limited_gather(
+    coros: Iterable[Callable[[], Awaitable[T]]],
+    limit: int = 5,
+    retries: int = 3,
+) -> List[T]:
+    """Run coroutines with a concurrency limit and basic exponential backoff."""
+
+    semaphore = asyncio.Semaphore(limit)
+
+    async def run_with_sem(coro_factory: Callable[[], Awaitable[T]]) -> T:
+        delay = 1.0
+        for attempt in range(retries):
+            async with semaphore:
+                try:
+                    return await coro_factory()
+                except Exception:
+                    if attempt == retries - 1:
+                        raise
+            await asyncio.sleep(delay)
+            delay *= 2
+        raise RuntimeError("Unreachable")
+
+    return await asyncio.gather(*(run_with_sem(c) for c in coros))

--- a/ai_automation/multi_api_enrichment/enrich.py
+++ b/ai_automation/multi_api_enrichment/enrich.py
@@ -1,0 +1,74 @@
+"""Enrich product descriptions with headlines, audio, and images."""
+
+import os
+import asyncio
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+import aiohttp
+import openai
+
+from async_utils import rate_limited_gather
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+SORA_API_URL = os.getenv("SORA_API_URL")
+MIDJOURNEY_API_URL = os.getenv("MIDJOURNEY_API_URL")
+MIDJOURNEY_API_KEY = os.getenv("MIDJOURNEY_API_KEY")
+
+openai.api_key = OPENAI_API_KEY
+
+AUDIO_DIR = Path("audio")
+IMAGE_DIR = Path("images")
+
+AUDIO_DIR.mkdir(exist_ok=True)
+IMAGE_DIR.mkdir(exist_ok=True)
+
+async def create_headline(text: str) -> str:
+    """Use OpenAI to create a short marketing headline."""
+    resp = await openai.ChatCompletion.acreate(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "You write punchy marketing headlines."},
+            {"role": "user", "content": text},
+        ],
+    )
+    return resp.choices[0].message.content.strip()
+
+async def fetch_audio(session: aiohttp.ClientSession, product_id: str, text: str) -> None:
+    """Request text-to-speech audio and save to disk."""
+    async with session.post(SORA_API_URL, json={"text": text}) as resp:
+        content = await resp.read()
+    (AUDIO_DIR / f"{product_id}.mp3").write_bytes(content)
+
+async def fetch_image(session: aiohttp.ClientSession, product_id: str, prompt: str) -> None:
+    """Request an image from Midjourney-compatible API and save to disk."""
+    payload = {"prompt": prompt, "api_key": MIDJOURNEY_API_KEY}
+    async with session.post(MIDJOURNEY_API_URL, json=payload) as resp:
+        content = await resp.read()
+    (IMAGE_DIR / f"{product_id}.png").write_bytes(content)
+
+async def process_product(session: aiohttp.ClientSession, row: Dict[str, Any]) -> Dict[str, Any]:
+    """Enrich a single product record."""
+    product_id = str(row["product_id"])
+    text = str(row["text"])
+    headline = await create_headline(text)
+    await asyncio.gather(
+        fetch_audio(session, product_id, headline),
+        fetch_image(session, product_id, headline),
+    )
+    return {"product_id": product_id, "headline": headline}
+
+async def main(csv_path: str = "products.csv") -> None:
+    df = pd.read_csv(csv_path)
+
+    async with aiohttp.ClientSession() as session:
+        tasks = [lambda row=row: process_product(session, row) for _, row in df.iterrows()]
+        results = await rate_limited_gather(tasks, limit=3)
+
+    result_df = pd.DataFrame(results)
+    merged = df.merge(result_df, on="product_id")
+    merged.to_csv("enriched.csv", index=False)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai_automation/multi_api_enrichment/requirements.txt
+++ b/ai_automation/multi_api_enrichment/requirements.txt
@@ -1,0 +1,4 @@
+openai
+requests
+aiohttp
+pandas


### PR DESCRIPTION
## Summary
- create **multi_api_enrichment** folder
- add async helpers
- implement enrichment pipeline calling OpenAI, Sora and Midjourney
- document the flow and concurrency model
- specify dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twilio')*
- `pip install twilio` *(fails: Could not find a version that satisfies the requirement twilio)*

------
https://chatgpt.com/codex/tasks/task_e_684a0f8c591c832797303719f7bb6f3b