### PR TITLE
Add June onboarding video pipeline

### DIFF
--- a/ai_automation/june_onboarding_videos/README.md
+++ b/ai_automation/june_onboarding_videos/README.md
@@ -1,0 +1,49 @@
+# June Onboarding Video Pipeline
+
+This example demonstrates a basic automation pipeline that generates personalized onboarding
+videos for customers who signed up in June 2025. The workflow pulls customer
+records from a CRM, creates avatar videos with HeyGen, uploads the videos to
+cloud storage, and emails links to the customers.
+
+## Files
+
+- `pipeline.py` – Orchestrates the full workflow.
+- `crm_client.py` – Queries the CRM API with date filters and pagination.
+- `video_client.py` – Calls the HeyGen avatar API to create a short video.
+- `mailer.py` – Sends transactional email with a video link.
+- `report.py` – Collects success/failure metrics.
+- `requirements.txt` – Required Python packages.
+
+## CRM Query
+
+`CRMClient.query_customers()` accepts `start_date` and `end_date` parameters.
+The function issues HTTP GET requests to `$CRM_API_URL/customers` using the
+`$CRM_API_KEY` for authentication. Results are paginated by a `next_page`
+field in the JSON response, so the client continues fetching pages until no
+`next_page` remains.
+
+## Concurrency and Rate Limits
+
+`pipeline.py` processes many customers concurrently using a
+`ThreadPoolExecutor`. Because external services may enforce API rate limits,
+the pipeline throttles to five video generation calls per second. If more tasks
+are queued, execution waits until enough time has passed.
+
+## Configuration
+
+Set the following environment variables before running the pipeline:
+
+- `CRM_API_URL` and `CRM_API_KEY` – Credentials for the CRM service.
+- `HEYGEN_API_KEY` – API key for the HeyGen avatar service.
+- `S3_BUCKET` or `GCS_BUCKET` – Cloud storage destination for videos.
+- `SENDGRID_API_KEY` or SMTP credentials – For sending email.
+
+The email and video templates can be customized by editing the strings in
+`video_client.py` and `mailer.py`.
+
+Run the pipeline:
+
+```bash
+python pipeline.py
+```
+

--- a/ai_automation/june_onboarding_videos/crm_client.py
+++ b/ai_automation/june_onboarding_videos/crm_client.py
@@ -1,0 +1,35 @@
+"""Simple CRM API client used by the onboarding video pipeline."""
+
+from __future__ import annotations
+
+import os
+import requests
+from typing import Dict, List
+
+CRM_API_URL = os.getenv("CRM_API_URL")
+CRM_API_KEY = os.getenv("CRM_API_KEY")
+
+
+class CRMClient:
+    """Client for querying customer records from the CRM service."""
+
+    def __init__(self) -> None:
+        if not CRM_API_URL or not CRM_API_KEY:
+            raise EnvironmentError("CRM_API_URL and CRM_API_KEY must be set")
+        self.base_url = CRM_API_URL.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {CRM_API_KEY}"})
+
+    def query_customers(self, start_date: str, end_date: str) -> List[Dict[str, str]]:
+        """Return all customers with signups between start and end dates."""
+        customers: List[Dict[str, str]] = []
+        params = {"start_date": start_date, "end_date": end_date}
+        url = f"{self.base_url}/customers"
+        while url:
+            resp = self.session.get(url, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            customers.extend(data.get("results", []))
+            url = data.get("next_page")
+            params = None  # next_page already contains query parameters
+        return customers

--- a/ai_automation/june_onboarding_videos/mailer.py
+++ b/ai_automation/june_onboarding_videos/mailer.py
@@ -1,0 +1,40 @@
+"""Utility for sending onboarding emails via SendGrid or SMTP."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
+SMTP_SERVER = os.getenv("SMTP_SERVER")
+SMTP_USERNAME = os.getenv("SMTP_USERNAME")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+FROM_EMAIL = os.getenv("FROM_EMAIL", "noreply@example.com")
+
+
+def send_email(to_email: str, subject: str, body: str) -> None:
+    """Send an email using SendGrid if configured, otherwise SMTP."""
+    if SENDGRID_API_KEY:
+        message = Mail(from_email=FROM_EMAIL, to_emails=to_email, subject=subject, html_content=body)
+        sg = SendGridAPIClient(SENDGRID_API_KEY)
+        sg.send(message)
+        return
+
+    if SMTP_SERVER and SMTP_USERNAME and SMTP_PASSWORD:
+        msg = EmailMessage()
+        msg["From"] = FROM_EMAIL
+        msg["To"] = to_email
+        msg["Subject"] = subject
+        msg.set_content(body, subtype="html")
+        with smtplib.SMTP(SMTP_SERVER) as server:
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.send_message(msg)
+        return
+
+    raise EnvironmentError("No email configuration found")
+

--- a/ai_automation/june_onboarding_videos/pipeline.py
+++ b/ai_automation/june_onboarding_videos/pipeline.py
@@ -1,0 +1,94 @@
+"""Generate onboarding videos for June 2025 signups."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict
+
+import boto3
+
+from crm_client import CRMClient
+from video_client import VideoClient
+from mailer import send_email
+from report import Report, Result
+
+START_DATE = "2025-06-01"
+END_DATE = "2025-06-30"
+VIDEO_TEMPLATE_ID = os.getenv("VIDEO_TEMPLATE_ID", "default")
+S3_BUCKET = os.getenv("S3_BUCKET")
+MAX_WORKERS = int(os.getenv("MAX_WORKERS", "5"))
+
+
+class RateLimiter:
+    def __init__(self, rate: int, per: float) -> None:
+        self.rate = rate
+        self.per = per
+        self.allowance = rate
+        self.last_check = time.monotonic()
+        self.lock = threading.Lock()
+
+    def wait(self) -> None:
+        while True:
+            with self.lock:
+                current = time.monotonic()
+                elapsed = current - self.last_check
+                self.last_check = current
+                self.allowance += elapsed * (self.rate / self.per)
+                if self.allowance > self.rate:
+                    self.allowance = self.rate
+                if self.allowance >= 1:
+                    self.allowance -= 1
+                    return
+            time.sleep(0.01)
+
+
+def upload_video(s3_client: boto3.client, customer_id: str, data: bytes) -> str:
+    key = f"onboarding/{customer_id}.mp4"
+    s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=data, ContentType="video/mp4")
+    return f"https://{S3_BUCKET}.s3.amazonaws.com/{key}"
+
+
+def process_customer(customer: Dict[str, str], video_client: VideoClient, s3_client: boto3.client, limiter: RateLimiter, report: Report) -> None:
+    start = time.monotonic()
+    cid = str(customer.get("id"))
+    try:
+        name = customer.get("name", "Customer")
+        plan = customer.get("plan", "our service")
+        email = customer.get("email")
+        script = f"Hi {name}, welcome to {plan}! We're excited to have you."
+        limiter.wait()
+        video_data = video_client.generate_video(script, VIDEO_TEMPLATE_ID)
+        link = upload_video(s3_client, cid, video_data)
+        if email:
+            body = f"<p>Your onboarding video is ready: <a href='{link}'>watch here</a>.</p>"
+            send_email(email, "Welcome to our service", body)
+        report.add(Result(cid, True, time.monotonic() - start))
+    except Exception as exc:  # pragma: no cover - simple example
+        report.add(Result(cid, False, time.monotonic() - start, str(exc)))
+
+
+def main() -> None:
+    if not S3_BUCKET:
+        raise EnvironmentError("S3_BUCKET must be set")
+    crm = CRMClient()
+    video_client = VideoClient()
+    s3_client = boto3.client("s3")
+    limiter = RateLimiter(rate=5, per=1.0)
+    report = Report()
+
+    customers = crm.query_customers(START_DATE, END_DATE)
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = [executor.submit(process_customer, c, video_client, s3_client, limiter, report) for c in customers]
+        for f in as_completed(futures):
+            pass
+
+    print(report.summary())
+
+
+if __name__ == "__main__":
+    main()
+

--- a/ai_automation/june_onboarding_videos/report.py
+++ b/ai_automation/june_onboarding_videos/report.py
@@ -1,0 +1,37 @@
+"""Collects pipeline execution metrics."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Result:
+    customer_id: str
+    success: bool
+    latency: float
+    error: str | None = None
+
+
+@dataclass
+class Report:
+    results: List[Result] = field(default_factory=list)
+
+    def add(self, result: Result) -> None:
+        self.results.append(result)
+
+    def summary(self) -> str:
+        total = len(self.results)
+        succeeded = sum(1 for r in self.results if r.success)
+        failed = total - succeeded
+        latencies = [r.latency for r in self.results]
+        avg_latency = statistics.mean(latencies) if latencies else 0.0
+        return (
+            f"Total: {total}\n"
+            f"Succeeded: {succeeded}\n"
+            f"Failed: {failed}\n"
+            f"Average latency: {avg_latency:.2f}s"
+        )
+

--- a/ai_automation/june_onboarding_videos/requirements.txt
+++ b/ai_automation/june_onboarding_videos/requirements.txt
@@ -1,0 +1,4 @@
+requests
+boto3
+sendgrid
+pandas

--- a/ai_automation/june_onboarding_videos/video_client.py
+++ b/ai_automation/june_onboarding_videos/video_client.py
@@ -1,0 +1,34 @@
+"""Client for generating onboarding videos using the HeyGen avatar API."""
+
+from __future__ import annotations
+
+import os
+import requests
+from typing import Any
+
+HEYGEN_API_KEY = os.getenv("HEYGEN_API_KEY")
+HEYGEN_URL = os.getenv("HEYGEN_URL", "https://api.heygen.com/v1")
+
+
+class VideoClient:
+    def __init__(self) -> None:
+        if not HEYGEN_API_KEY:
+            raise EnvironmentError("HEYGEN_API_KEY must be set")
+        self.base_url = HEYGEN_URL.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {HEYGEN_API_KEY}"})
+
+    def generate_video(self, script: str, template_id: str) -> bytes:
+        """Request video generation and return binary MP4 data."""
+        resp = self.session.post(
+            f"{self.base_url}/videos",
+            json={"script": script, "template_id": template_id},
+        )
+        resp.raise_for_status()
+        video_url = resp.json().get("video_url")
+        if not video_url:
+            raise RuntimeError("No video URL returned")
+        video_resp = self.session.get(video_url)
+        video_resp.raise_for_status()
+        return video_resp.content
+


### PR DESCRIPTION
## Summary
- create `june_onboarding_videos` example folder under `ai_automation`
- implement pipeline to query a CRM, generate HeyGen videos, upload to S3, and send email
- add supporting modules for CRM client, video generation, email sending, and result reporting
- document configuration and usage

## Testing
- `python -m py_compile ai_automation/june_onboarding_videos/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f9306f88327bfe8eec3b9f9b0c6