### PR TITLE
Add Sora TTS dataset builder

### DIFF
--- a/ai_automation/sora_tts_dataset/README.md
+++ b/ai_automation/sora_tts_dataset/README.md
@@ -1,0 +1,36 @@
+# Sora TTS Dataset Builder
+
+This folder contains a small package for generating a text-to-speech dataset using the **Sora** API.
+
+## Voice styles
+
+The API supports multiple voices. Typical styles include `narrator`, `conversational`, and `energetic`. Each block in the JSON input selects a style with the `voice_style` field.
+
+## Running
+
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the environment variable `SORA_API_KEY` with your API key.
+3. Provide a JSON file containing objects like:
+   ```json
+   [
+     {"id": "promo1", "text": "Sale starts today", "voice_style": "narrator"},
+     {"id": "promo2", "text": "Don't miss out", "voice_style": "energetic"}
+   ]
+   ```
+4. Run the builder:
+   ```bash
+   python -m sora_tts_dataset.build marketing_copy.json output_dir
+   ```
+
+The script saves MP3 files and writes `sora_dataset.csv` with the metadata.
+
+## Error handling and rate limits
+
+API errors are raised if a request fails. When a `429` status code is returned, the script waits for the `Retry-After` time before retrying the request.
+
+## Verifying durations
+
+The duration of each clip is taken from the `X-Duration-Seconds` response header. This value is recorded in the CSV so you can confirm audio lengths after download.

--- a/ai_automation/sora_tts_dataset/build.py
+++ b/ai_automation/sora_tts_dataset/build.py
@@ -1,0 +1,77 @@
+"""Build an audio dataset using the Sora TTS API."""
+
+import argparse
+import json
+import os
+import time
+from typing import List, Dict
+
+import pandas as pd
+import requests
+
+from .config import load_api_key
+
+TTS_URL = "https://api.sora.com/v1/tts"
+
+
+def load_copy(path: str) -> List[Dict[str, str]]:
+    """Load marketing copy blocks from a JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def synthesize(copy_blocks: List[Dict[str, str]], output_dir: str) -> pd.DataFrame:
+    """Synthesize audio for each copy block and return metadata."""
+    api_key = load_api_key()
+    os.makedirs(output_dir, exist_ok=True)
+    session = requests.Session()
+    headers = {"Authorization": f"Bearer {api_key}"}
+    rows = []
+
+    for block in copy_blocks:
+        text = block.get("text", "")
+        voice = block.get("voice_style", "default")
+        payload = {"text": text, "voice": voice}
+        while True:
+            resp = session.post(TTS_URL, json=payload, headers=headers)
+            if resp.status_code == 429:
+                wait = int(resp.headers.get("Retry-After", "1"))
+                time.sleep(wait)
+                continue
+            if resp.status_code != 200:
+                raise RuntimeError(f"API error {resp.status_code}: {resp.text}")
+            break
+        file_name = f"{block.get('id')}_{voice}.mp3"
+        file_path = os.path.join(output_dir, file_name)
+        with open(file_path, "wb") as f:
+            f.write(resp.content)
+        duration = float(resp.headers.get("X-Duration-Seconds", 0))
+        rows.append(
+            {
+                "id": block.get("id"),
+                "voice_style": voice,
+                "duration_sec": duration,
+                "file_path": file_path,
+            }
+        )
+    df = pd.DataFrame(rows)
+    df.to_csv(os.path.join(output_dir, "sora_dataset.csv"), index=False)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a Sora TTS dataset")
+    parser.add_argument("json_path", help="Path to marketing copy JSON list")
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default=".",
+        help="Directory to write MP3 files and metadata",
+    )
+    args = parser.parse_args()
+    blocks = load_copy(args.json_path)
+    synthesize(blocks, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_automation/sora_tts_dataset/config.py
+++ b/ai_automation/sora_tts_dataset/config.py
@@ -1,0 +1,9 @@
+import os
+
+
+def load_api_key() -> str:
+    """Return the Sora API key from the environment."""
+    key = os.getenv("SORA_API_KEY")
+    if not key:
+        raise EnvironmentError("SORA_API_KEY environment variable not set")
+    return key

--- a/ai_automation/sora_tts_dataset/requirements.txt
+++ b/ai_automation/sora_tts_dataset/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas


### PR DESCRIPTION
## Summary
- add new `sora_tts_dataset` package to `ai_automation`
- implement dataset builder for Sora TTS API
- document voice styles, error handling and duration checks
- include minimal requirements list

## Testing
- `python -m py_compile ai_automation/sora_tts_dataset/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f80bec8832793ac22ce627434e1