### PR TITLE
Add HeyGen avatar batch pipeline

### DIFF
--- a/ai_automation/heygen_avatar_batch/README.md
+++ b/ai_automation/heygen_avatar_batch/README.md
@@ -1,0 +1,44 @@
+# HeyGen Avatar Batch Pipeline
+
+This folder demonstrates a basic pipeline for generating video avatars in bulk using the HeyGen API.
+
+## Files
+
+- `avatar_generator.py` – reads an Excel roster and coordinates the avatar creation process
+- `poller.py` – simple helper for polling the status endpoint
+- `requirements.txt` – minimal dependencies (`openpyxl`, `requests`, `pandas`)
+
+## Excel Template Format
+
+The roster Excel file should contain a sheet with the following columns:
+
+| user_id | name | avatar_template |
+| ------- | ---- | --------------- |
+| 001 | Alice | friendly_bot |
+| 002 | Bob | futuristic |
+
+Each row represents a user profile. `avatar_template` is the HeyGen template ID to use for that user.
+
+## Polling Settings
+
+`poller.Poller` accepts two optional parameters:
+
+- `interval` – seconds to wait between status checks (default `5`)
+- `timeout` – maximum seconds to wait before giving up (default `300`)
+
+You can adjust these values in `process_excel()` if your jobs take longer to complete.
+
+## Previewing Videos
+
+Generated videos are downloaded to the `output/` directory with the filename `<user_id>.mp4`. Open the files in any video player to preview the avatars. The CSV `generation_log.csv` records the completion time, status, and video URL returned by HeyGen for later reference.
+
+### Running
+
+Install dependencies and run the script:
+
+```bash
+pip install -r requirements.txt
+python avatar_generator.py
+```
+
+You will be prompted for the path to your Excel roster.

--- a/ai_automation/heygen_avatar_batch/avatar_generator.py
+++ b/ai_automation/heygen_avatar_batch/avatar_generator.py
@@ -1,0 +1,63 @@
+"""Batch avatar generation using HeyGen API."""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+import requests
+
+from poller import Poller
+
+API_BASE_URL = os.getenv("HEYGEN_API_BASE_URL", "https://api.heygen.com")
+API_KEY = os.getenv("HEYGEN_API_KEY")
+OUTPUT_DIR = Path("output")
+LOG_FILE = Path("generation_log.csv")
+
+
+def create_avatar(template: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Call HeyGen create avatar endpoint."""
+    url = f"{API_BASE_URL}/v1/avatar/create"
+    headers = {"Authorization": f"Bearer {API_KEY}"}
+    response = requests.post(url, headers=headers, json={"template": template, "metadata": metadata})
+    response.raise_for_status()
+    return response.json()
+
+
+def download_video(video_url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    r = requests.get(video_url)
+    r.raise_for_status()
+    with open(dest, "wb") as f:
+        f.write(r.content)
+
+
+def process_excel(path: str, interval: int = 5, timeout: int = 300) -> None:
+    df = pd.read_excel(path)
+    poller = Poller(interval=interval, timeout=timeout)
+
+    with open(LOG_FILE, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["user_id", "timestamp", "status", "video_url"])
+
+        for _, row in df.iterrows():
+            user_id = row["user_id"]
+            name = row.get("name", "")
+            template = row["avatar_template"]
+
+            meta = {"name": name, "user_id": user_id}
+            creation = create_avatar(template, meta)
+            status_url = creation.get("status_url")
+
+            result = poller.poll(lambda: requests.get(status_url, headers={"Authorization": f"Bearer {API_KEY}"}))
+            video_url = result.get("video_url")
+            download_video(video_url, OUTPUT_DIR / f"{user_id}.mp4")
+            writer.writerow([user_id, result.get("completed_at"), result.get("status"), video_url])
+
+
+if __name__ == "__main__":
+    excel_path = input("Path to Excel roster: ")
+    process_excel(excel_path)

--- a/ai_automation/heygen_avatar_batch/poller.py
+++ b/ai_automation/heygen_avatar_batch/poller.py
@@ -1,0 +1,29 @@
+"""Utility for polling HeyGen avatar generation status."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, Any
+
+import requests
+
+
+class Poller:
+    """Poll a status endpoint until generation is complete."""
+
+    def __init__(self, interval: int = 5, timeout: int = 300) -> None:
+        self.interval = interval
+        self.timeout = timeout
+
+    def poll(self, func: Callable[[], requests.Response]) -> Dict[str, Any]:
+        """Polls ``func`` until it returns a completed status or times out."""
+        start = time.time()
+        while True:
+            resp = func()
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("status") == "completed":
+                return data
+            if time.time() - start > self.timeout:
+                raise TimeoutError("Avatar generation timed out")
+            time.sleep(self.interval)

--- a/ai_automation/heygen_avatar_batch/requirements.txt
+++ b/ai_automation/heygen_avatar_batch/requirements.txt
@@ -1,0 +1,3 @@
+openpyxl
+requests
+pandas


### PR DESCRIPTION
## Summary
- add `heygen_avatar_batch` example under `ai_automation`
- implement `avatar_generator.py` and `poller.py`
- document Excel format and polling settings
- include requirements for openpyxl, requests and pandas

## Testing
- `python -m py_compile ai_automation/heygen_avatar_batch/*.py`
- `python ai_automation/heygen_avatar_batch/avatar_generator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a0f85d1b48327bfc4c0f9602d0c6b