### PR TITLE
Add ChatGPT prompt dataset builder

### DIFF
--- a/ai_automation/chatgpt_prompt_dataset/README.md
+++ b/ai_automation/chatgpt_prompt_dataset/README.md
@@ -1,0 +1,31 @@
+# ChatGPT Prompt Dataset Builder
+
+This folder demonstrates how to turn a spreadsheet of business scenarios into a dataset of prompts and ChatGPT responses.
+
+## Files
+- `generate.py` – reads scenarios and writes the resulting dataset.
+- `utils.py` – helper functions for payload creation and retry logic.
+- `requirements.txt` – dependencies (`openai`, `pandas`, `tenacity`).
+
+## Input CSV Format
+The input file must include the columns `scenario_id`, `description`, and `tone`. Example:
+
+```
+scenario_id,description,tone
+1,"Analyze the market for winter coats","formal"
+2,"Suggest a slogan for a family restaurant","friendly"
+```
+
+## Usage
+Install the requirements and set your OpenAI API key:
+
+```
+pip install -r requirements.txt
+export OPENAI_API_KEY=YOUR_KEY
+python generate.py scenarios.csv dataset.csv
+```
+
+For each scenario the script builds a payload for OpenAI's ChatCompletion API and captures the assistant reply. The resulting `dataset.csv` contains the columns `scenario_id`, `prompt`, `response`, and `tokens_used`.
+
+## Token Usage and Errors
+The `tokens_used` column is populated from the API response's `usage.total_tokens` field. Rate-limit errors are logged, and the request is retried with exponential backoff. If a call ultimately fails, an exception is raised and the logs will indicate the error.

--- a/ai_automation/chatgpt_prompt_dataset/generate.py
+++ b/ai_automation/chatgpt_prompt_dataset/generate.py
@@ -1,0 +1,40 @@
+"""Generate a prompt/response dataset from business scenarios."""
+
+import os
+import sys
+import pandas as pd
+import openai
+
+from utils import build_payload, chat_completion_with_retry
+
+
+def main(input_csv: str, output_csv: str) -> None:
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if not openai.api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
+    scenarios = pd.read_csv(input_csv)
+    records = []
+
+    for _, row in scenarios.iterrows():
+        description = row.get("description", "")
+        scenario_id = row.get("scenario_id")
+        payload = build_payload(description)
+        response = chat_completion_with_retry(payload)
+        message = response.choices[0].message["content"].strip()
+        tokens = response.usage.total_tokens if getattr(response, "usage", None) else None
+        records.append({
+            "scenario_id": scenario_id,
+            "prompt": description,
+            "response": message,
+            "tokens_used": tokens,
+        })
+
+    pd.DataFrame(records).to_csv(output_csv, index=False)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python generate.py <input_csv> <output_csv>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/ai_automation/chatgpt_prompt_dataset/requirements.txt
+++ b/ai_automation/chatgpt_prompt_dataset/requirements.txt
@@ -1,0 +1,3 @@
+openai
+pandas
+tenacity

--- a/ai_automation/chatgpt_prompt_dataset/utils.py
+++ b/ai_automation/chatgpt_prompt_dataset/utils.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Any, Dict
+
+import openai
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
+
+logger = logging.getLogger(__name__)
+
+
+def build_payload(description: str) -> Dict[str, Any]:
+    """Construct the ChatCompletion payload for a scenario description."""
+    return {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "system", "content": "You are an expert business analyst."},
+            {"role": "user", "content": description},
+        ],
+        "temperature": 0.7,
+    }
+
+
+@retry(
+    retry=retry_if_exception_type(openai.error.RateLimitError),
+    wait=wait_exponential(multiplier=1, min=1, max=60),
+    stop=stop_after_attempt(5),
+    reraise=True,
+)
+def chat_completion_with_retry(payload: Dict[str, Any]) -> Any:
+    """Call the OpenAI API with retry logic for rate limits."""
+    try:
+        return openai.ChatCompletion.create(**payload)
+    except openai.error.RateLimitError as e:
+        logger.warning("Rate limit hit: %s. Retrying...", e)
+        raise
+


### PR DESCRIPTION
## Summary
- create **chatgpt_prompt_dataset** module under `ai_automation`
- implement `generate.py` for converting scenarios into dataset CSV
- add payload builder and retry logic in `utils.py`
- include README explaining usage
- specify requirements (`openai`, `pandas`, `tenacity`)

## Testing
- `python -m py_compile ai_automation/chatgpt_prompt_dataset/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684a0f7b20e08327986d0eb725df56c8