### PR TITLE
Add document summarization example

### DIFF
--- a/ai_automation/document_summarization/README.md
+++ b/ai_automation/document_summarization/README.md
@@ -1,0 +1,38 @@
+# Document Summarization Example
+
+This folder demonstrates a small pipeline that creates executive summaries for a batch of text files using OpenAI's Chat API.
+
+## Files
+
+- `summarize.py` – reads `.txt` documents from a directory, splits each into manageable chunks, requests summaries from ChatGPT, assembles the results, and saves markdown files.
+- `requirements.txt` – minimal dependencies (`openai`, `pandas`).
+
+## Text-splitting logic and chunk size
+
+Documents are divided into pieces of roughly **2000 characters**. This keeps each request well under the 4k token context window for `gpt-3.5-turbo` while leaving room for the prompt and summary. Adjust `CHUNK_SIZE` in `summarize.py` if your documents are significantly shorter or longer.
+
+## Tuning the prompt
+
+`summarize.py` uses the system prompt:
+
+```
+Provide a concise executive summary for the given text.
+```
+
+Edit `SYSTEM_PROMPT` in the script to request more detail or a different style of summary. For longer outputs, you can also increase the model's `max_tokens` parameter when calling the API.
+
+## Running on a new batch
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY=YOUR_KEY
+   ```
+3. Place your `.txt` files in a folder and run:
+   ```bash
+   python summarize.py
+   ```
+   The program will prompt for the location of the text files and an output directory. Each document's full text and final summary will be saved as markdown files in the output folder.

--- a/ai_automation/document_summarization/requirements.txt
+++ b/ai_automation/document_summarization/requirements.txt
@@ -1,0 +1,2 @@
+openai
+pandas

--- a/ai_automation/document_summarization/summarize.py
+++ b/ai_automation/document_summarization/summarize.py
@@ -1,0 +1,65 @@
+"""Generate document summaries using OpenAI's ChatCompletion API."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+import openai
+import pandas as pd
+
+# Approximate number of characters to send in each API call.
+CHUNK_SIZE = 2000
+
+SYSTEM_PROMPT = "Provide a concise executive summary for the given text."
+
+
+def load_documents(directory: Path) -> List[Path]:
+    """Return a list of text files in the given directory."""
+    return [p for p in directory.glob("*.txt") if p.is_file()]
+
+
+def split_text(text: str, size: int = CHUNK_SIZE) -> List[str]:
+    """Split text into character-based chunks."""
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def summarize(text: str) -> str:
+    """Summarize a single chunk using the ChatCompletion API."""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": text},
+        ],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def summarize_document(path: Path, out_dir: Path) -> pd.Series:
+    """Summarize one document and save markdown outputs."""
+    text = path.read_text()
+    chunks = split_text(text)
+
+    chunk_summaries = [summarize(c) for c in chunks]
+    final_summary = summarize("\n\n".join(chunk_summaries))
+
+    out_dir.mkdir(exist_ok=True)
+    (out_dir / f"{path.stem}.md").write_text(text)
+    (out_dir / f"{path.stem}_summary.md").write_text(final_summary)
+
+    return pd.Series({"file": path.name, "summary": final_summary})
+
+
+def main() -> None:
+    doc_dir = Path(input("Directory of text files: ").strip())
+    out_dir = Path(input("Output directory [summaries]: ").strip() or "summaries")
+
+    results = [summarize_document(p, out_dir) for p in load_documents(doc_dir)]
+    df = pd.DataFrame(results)
+    print(df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add document_summarization example under ai_automation
- include OpenAI-based summarization script
- document usage and parameters
- list minimal dependencies

## Testing
- `python -m py_compile ai_automation/document_summarization/summarize.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f1d45488327a9bf72b7620625cc