### PR TITLE
Add FAQ Chatbot example

### DIFF
--- a/ai_automation/faq_chatbot/README.md
+++ b/ai_automation/faq_chatbot/README.md
@@ -1,0 +1,42 @@
+# FAQ Chatbot Example
+
+This folder demonstrates a simple FAQ chatbot built with FastAPI. The app loads
+questions and answers from `faq.csv`, indexes the questions with a
+SentenceTransformers model, and exposes an `/ask` endpoint that returns the most
+relevant answers for a user query.
+
+## Embedding model
+
+- **Model:** `all-MiniLM-L6-v2`
+- **Similarity threshold:** `0.5`
+
+Any FAQ whose cosine similarity score is below the threshold is filtered out.
+
+## Retraining
+
+When you add new questions to `faq.csv`, restart the server to rebuild the
+embeddings. The `FAQIndexer` class automatically reloads the CSV on startup.
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the API with uvicorn:
+   ```bash
+   uvicorn ai_automation.faq_chatbot.app:app --reload
+   ```
+
+## Usage example
+
+Ask a question with curl:
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"question": "How can I track my order?"}' \
+     http://localhost:8000/ask
+```
+Example response:
+```json
+{"answers": ["Use the tracking link in your confirmation email."]}
+```

--- a/ai_automation/faq_chatbot/app.py
+++ b/ai_automation/faq_chatbot/app.py
@@ -1,0 +1,19 @@
+"""FastAPI app exposing a FAQ chatbot endpoint."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .embeddings import FAQIndexer
+
+indexer = FAQIndexer()
+app = FastAPI(title="FAQ Chatbot")
+
+class Question(BaseModel):
+    question: str
+
+@app.post("/ask")
+async def ask(data: Question):
+    """Return answers to the most similar FAQs."""
+    results = indexer.query(data.question)
+    answers = [r["answer"] for r in results]
+    return {"answers": answers}

--- a/ai_automation/faq_chatbot/embeddings.py
+++ b/ai_automation/faq_chatbot/embeddings.py
@@ -1,0 +1,40 @@
+"""FAQ indexing utilities using sentence-transformers."""
+
+from pathlib import Path
+from typing import List, Dict
+
+import pandas as pd
+from sentence_transformers import SentenceTransformer, util
+import torch
+
+MODEL_NAME = "all-MiniLM-L6-v2"
+SIM_THRESHOLD = 0.5
+
+class FAQIndexer:
+    """Load FAQs and perform similarity search."""
+
+    def __init__(self, csv_path: str = "faq.csv", model_name: str = MODEL_NAME):
+        csv_file = Path(__file__).resolve().parent / csv_path
+        self.df = pd.read_csv(csv_file)
+        self.questions = self.df["question"].fillna("").tolist()
+        self.answers = self.df["answer"].fillna("").tolist()
+        self.model = SentenceTransformer(model_name)
+        self.embeddings = self.model.encode(self.questions, convert_to_tensor=True)
+
+    def query(self, text: str, top_k: int = 3) -> List[Dict[str, str]]:
+        """Return the most similar FAQs above the similarity threshold."""
+        query_emb = self.model.encode(text, convert_to_tensor=True)
+        scores = util.cos_sim(query_emb, self.embeddings)[0]
+        k = min(top_k, len(self.questions))
+        best_scores, best_idx = torch.topk(scores, k=k)
+        results = []
+        for score, idx in zip(best_scores, best_idx):
+            if score.item() >= SIM_THRESHOLD:
+                results.append(
+                    {
+                        "question": self.questions[idx],
+                        "answer": self.answers[idx],
+                        "score": float(score.item()),
+                    }
+                )
+        return results

--- a/ai_automation/faq_chatbot/faq.csv
+++ b/ai_automation/faq_chatbot/faq.csv
@@ -1,0 +1,4 @@
+question,answer
+What is your return policy?,You can return items within 30 days for a full refund.
+How do I track my order?,Use the tracking link in your confirmation email.
+Do you offer international shipping?,Yes, we ship worldwide.

--- a/ai_automation/faq_chatbot/requirements.txt
+++ b/ai_automation/faq_chatbot/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sentence-transformers
+pandas


### PR DESCRIPTION
## Summary
- add a `faq_chatbot` example to ai_automation
- embed FAQs with sentence-transformers
- expose a FastAPI `/ask` endpoint for querying questions
- provide requirements and documentation

## Testing
- `python -m py_compile ai_automation/faq_chatbot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f22661883279d2a014454364647