### PR TITLE
Add T‑shirt e‑commerce workflow example

### DIFF
--- a/ai_automation/tshirt_ecommerce_store/.env.example
+++ b/ai_automation/tshirt_ecommerce_store/.env.example
@@ -1,0 +1,8 @@
+MIDJOURNEY_API_URL=https://api.example.com/midjourney
+S3_BUCKET_URL=https://bucket.s3.amazonaws.com
+STRIPE_API_KEY=sk_test_yourkey
+PRINTFUL_URL=https://api.printful.com/orders
+PRINTFUL_TOKEN=your_printful_token
+SHIPPING_URL_TEMPLATE=https://api.printful.com/orders/{production_id}
+DB_PATH=orders.db
+TSHIRT_PRICE_CENTS=2000

--- a/ai_automation/tshirt_ecommerce_store/README.md
+++ b/ai_automation/tshirt_ecommerce_store/README.md
@@ -1,0 +1,32 @@
+# T-Shirt Ecommerce Store
+
+This example demonstrates a simplified end-to-end workflow for a print-on-demand T‑shirt business. The FastAPI service exposes a single `/order` endpoint that accepts a design prompt and payment token and coordinates design generation, payment, production, and shipping.
+
+## Environment Variables
+Create a `.env` file based on `.env.example` and set the following keys:
+
+- `MIDJOURNEY_API_URL` – image generation endpoint
+- `S3_BUCKET_URL` – storage upload URL
+- `STRIPE_API_KEY` – Stripe secret key
+- `PRINTFUL_URL` and `PRINTFUL_TOKEN` – print-on-demand API credentials
+- `SHIPPING_URL_TEMPLATE` – URL to check order shipping status
+- `DB_PATH` – path to SQLite DB (e.g. `orders.db`)
+- `TSHIRT_PRICE_CENTS` – price charged in cents
+
+## Running
+Install dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Example Order Request
+```bash
+curl -X POST http://localhost:8000/order \
+  -H "Content-Type: application/json" \
+  -d '{"customer": {"name": "Jane Doe", "email": "jane@example.com", "address": {"line1": "123 Main St", "city": "Toronto", "postal_code": "A1A1A1", "country": "CA"}}, "design_prompt": "a minimalist mountain scene in pastel colors", "tshirt": {"size": "L", "color": "white"}, "payment_token": "tok_test"}'
+```
+
+## Logs and Orders
+Logs are written to `store.log` in this folder. Order records are saved to the SQLite database specified by `DB_PATH`. Use any SQLite browser or the `sqlite3` CLI to inspect the `orders` table.

--- a/ai_automation/tshirt_ecommerce_store/config.py
+++ b/ai_automation/tshirt_ecommerce_store/config.py
@@ -1,0 +1,22 @@
+"""Configuration and logging setup for T-shirt store."""
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+BASE_DIR = Path(__file__).resolve().parent
+LOG_FILE = BASE_DIR / 'store.log'
+
+# Load environment variables
+ENV_PATH = os.getenv('ENV_PATH', BASE_DIR / '.env')
+if isinstance(ENV_PATH, Path):
+    ENV_PATH = str(ENV_PATH)
+load_dotenv(ENV_PATH)
+
+logger = logging.getLogger('tshirt_store')
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+file_handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)

--- a/ai_automation/tshirt_ecommerce_store/design.py
+++ b/ai_automation/tshirt_ecommerce_store/design.py
@@ -1,0 +1,29 @@
+"""Design generation module."""
+import os
+import requests
+from .config import logger
+from .utils import DesignError
+
+MIDJOURNEY_API_URL = os.getenv('MIDJOURNEY_API_URL')
+S3_BUCKET_URL = os.getenv('S3_BUCKET_URL')
+
+
+def generate_design(prompt: str) -> str:
+    """Generate design image and upload to cloud storage.
+
+    Returns public URL of uploaded image.
+    """
+    try:
+        response = requests.post(MIDJOURNEY_API_URL, json={"prompt": prompt}, timeout=30)
+        response.raise_for_status()
+        image_data = response.content
+        # Upload to storage (placeholder)
+        upload_resp = requests.post(S3_BUCKET_URL, files={"file": image_data}, timeout=30)
+        upload_resp.raise_for_status()
+        url = upload_resp.json().get("url")
+        if not url:
+            raise DesignError("Upload failed")
+        return url
+    except Exception as exc:
+        logger.exception("Design generation failed")
+        raise DesignError("Design generation failed") from exc

--- a/ai_automation/tshirt_ecommerce_store/main.py
+++ b/ai_automation/tshirt_ecommerce_store/main.py
@@ -1,0 +1,52 @@
+"""FastAPI application entry point."""
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+from . import design, payment, production, shipping, report
+from .config import logger
+from .utils import DesignError, PaymentError, ProductionError, ShippingError
+
+app = FastAPI(title="T-Shirt Ecommerce Store")
+
+class Address(BaseModel):
+    line1: str
+    city: str
+    postal_code: str
+    country: str
+
+class Customer(BaseModel):
+    name: str
+    email: EmailStr
+    address: Address
+
+class Tshirt(BaseModel):
+    size: str
+    color: str
+
+class OrderRequest(BaseModel):
+    customer: Customer
+    design_prompt: str
+    tshirt: Tshirt
+    payment_token: str
+
+@app.post("/order")
+def create_order(order: OrderRequest):
+    try:
+        design_url = design.generate_design(order.design_prompt)
+        charge_id = payment.process_payment(order.payment_token)
+        production_id, _ = production.create_order(order.customer.dict(), order.tshirt.dict(), design_url)
+        tracking_url = shipping.wait_for_tracking(production_id)
+        report.init_db()
+        order_id = report.save_order(order.customer.dict(), design_url, charge_id, production_id, tracking_url)
+        return {
+            "order_id": order_id,
+            "design_url": design_url,
+            "charge_id": charge_id,
+            "production_id": production_id,
+            "tracking_url": tracking_url,
+        }
+    except (DesignError, PaymentError, ProductionError, ShippingError) as exc:
+        logger.error("Order failed: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Unexpected error")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/ai_automation/tshirt_ecommerce_store/payment.py
+++ b/ai_automation/tshirt_ecommerce_store/payment.py
@@ -1,0 +1,23 @@
+"""Payment processing using Stripe."""
+import os
+import stripe
+from .config import logger
+from .utils import PaymentError
+
+stripe.api_key = os.getenv('STRIPE_API_KEY')
+PRICE_CENTS = int(os.getenv('TSHIRT_PRICE_CENTS', '2000'))
+
+
+def process_payment(token: str, amount: int = PRICE_CENTS, currency: str = 'usd') -> str:
+    """Charge the payment token and return charge ID."""
+    try:
+        charge = stripe.Charge.create(
+            amount=amount,
+            currency=currency,
+            source=token,
+            description='T-shirt purchase',
+        )
+        return charge['id']
+    except stripe.error.StripeError as exc:
+        logger.exception("Payment failed")
+        raise PaymentError(str(exc)) from exc

--- a/ai_automation/tshirt_ecommerce_store/production.py
+++ b/ai_automation/tshirt_ecommerce_store/production.py
@@ -1,0 +1,31 @@
+"""Print-on-demand production integration."""
+import os
+import requests
+from .config import logger
+from .utils import ProductionError
+
+PRINTFUL_URL = os.getenv('PRINTFUL_URL')
+PRINTFUL_TOKEN = os.getenv('PRINTFUL_TOKEN')
+
+
+def create_order(customer: dict, tshirt: dict, design_url: str) -> tuple[str, str]:
+    """Send order to print-on-demand service.
+
+    Returns (production_id, estimated_ship_date).
+    """
+    try:
+        payload = {
+            'recipient': customer,
+            'items': [{
+                'variant': f"{tshirt['size']}-{tshirt['color']}",
+                'files': [{'url': design_url}],
+            }],
+        }
+        headers = {'Authorization': f'Bearer {PRINTFUL_TOKEN}'}
+        resp = requests.post(PRINTFUL_URL, json=payload, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return str(data.get('id')), data.get('estimated_ship_date')
+    except Exception as exc:
+        logger.exception("Production order failed")
+        raise ProductionError("Production order failed") from exc

--- a/ai_automation/tshirt_ecommerce_store/report.py
+++ b/ai_automation/tshirt_ecommerce_store/report.py
@@ -1,0 +1,38 @@
+"""Order reporting module using SQLite."""
+import sqlite3
+import os
+from pathlib import Path
+from .config import logger
+
+DB_PATH = Path(os.getenv('DB_PATH', 'orders.db'))
+
+
+def init_db() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            customer_name TEXT,
+            customer_email TEXT,
+            design_url TEXT,
+            charge_id TEXT,
+            production_id TEXT,
+            tracking_url TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_order(customer: dict, design_url: str, charge_id: str, production_id: str, tracking_url: str) -> int:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO orders (customer_name, customer_email, design_url, charge_id, production_id, tracking_url) VALUES (?, ?, ?, ?, ?, ?)",
+        (customer['name'], customer['email'], design_url, charge_id, production_id, tracking_url),
+    )
+    order_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    logger.info('Saved order %s', order_id)
+    return order_id

--- a/ai_automation/tshirt_ecommerce_store/requirements.txt
+++ b/ai_automation/tshirt_ecommerce_store/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+stripe
+requests
+boto3
+python-dotenv
+# sqlite3 is included in Python standard library

--- a/ai_automation/tshirt_ecommerce_store/shipping.py
+++ b/ai_automation/tshirt_ecommerce_store/shipping.py
@@ -1,0 +1,26 @@
+"""Shipping and tracking integration."""
+import os
+import time
+import requests
+from .config import logger
+from .utils import ShippingError
+
+SHIPPING_URL_TEMPLATE = os.getenv('SHIPPING_URL_TEMPLATE')
+
+
+def wait_for_tracking(production_id: str, attempts: int = 10, delay: int = 30) -> str:
+    """Poll shipping API until a tracking URL is available."""
+    try:
+        for _ in range(attempts):
+            url = SHIPPING_URL_TEMPLATE.format(production_id=production_id)
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            tracking = data.get('tracking_url')
+            if tracking:
+                return tracking
+            time.sleep(delay)
+        raise ShippingError('Tracking not available')
+    except Exception as exc:
+        logger.exception('Shipping tracking failed')
+        raise ShippingError('Shipping tracking failed') from exc

--- a/ai_automation/tshirt_ecommerce_store/utils.py
+++ b/ai_automation/tshirt_ecommerce_store/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions and custom exceptions."""
+
+class OrderError(Exception):
+    """Base exception for order workflow."""
+
+class DesignError(OrderError):
+    """Raised when design generation fails."""
+
+class PaymentError(OrderError):
+    """Raised when payment processing fails."""
+
+class ProductionError(OrderError):
+    """Raised when production API call fails."""
+
+class ShippingError(OrderError):
+    """Raised when shipping tracking fails."""


### PR DESCRIPTION
## Summary
- create `tshirt_ecommerce_store` FastAPI example
- implement design, payment, production, shipping, and report modules
- configure logging and environment variables
- provide requirements and README with usage instructions

## Testing
- `python -m py_compile ai_automation/tshirt_ecommerce_store/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a10b4ec5883278d9be88aa1313545