### PR TITLE
Add cafe inventory auto reorder example

### DIFF
--- a/ai_automation/cafe_inventory_autoreorder/README.md
+++ b/ai_automation/cafe_inventory_autoreorder/README.md
@@ -1,0 +1,65 @@
+# Cafe Inventory Auto-Reorder
+
+This folder contains a small pipeline that forecasts inventory depletion for a cafe and automatically places reorders with a supplier API.
+
+## Files
+
+- `forecast.py` – loads POS history and predicts daily sales using exponential smoothing.
+- `reorder.py` – checks forecasts against a safety level and posts reorders to the supplier API while logging each attempt.
+- `logger.py` – creates a SQLite `reorder_log.db` and stores API responses.
+- `report.py` – emails a daily summary of reorder activity and predicted stock-out dates.
+- `requirements.txt` – Python dependencies.
+
+## Forecasting
+
+`forecast.py` uses `statsmodels` `SimpleExpSmoothing` to estimate the next day's sales for each SKU. The forecast is projected 14 days forward. By default the safety stock level is **10 units** but can be overridden with the `SAFETY_LEVEL` environment variable.
+
+A reorder is triggered when the forecasted stock after 14 days falls below the safety level. The reorder amount brings inventory back to roughly twice the safety level.
+
+## Supplier API
+
+Set the following environment variables in a `.env` file:
+
+```
+SUPPLIER_API_URL=https://supplier.example.com
+SUPPLIER_API_TOKEN=your_token_here
+SAFETY_LEVEL=10
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+EMAIL_USER=bot@example.com
+EMAIL_PASS=password
+EMAIL_TO=manager@example.com
+```
+
+`reorder.py` POSTs to `$SUPPLIER_API_URL/orders` with JSON:
+
+```json
+{ "sku": "ABC123", "quantity": 20 }
+```
+
+The token is sent as a bearer token in the `Authorization` header.
+
+## Running Daily
+
+Install dependencies and run the pipeline with the latest POS CSV:
+
+```bash
+pip install -r requirements.txt
+python reorder.py path/to/daily_pos.csv
+```
+
+To run automatically each day, create a cron entry similar to:
+
+```
+0 2 * * * /usr/bin/python /path/to/reorder.py /data/pos_$(date +\%Y-\%m-\%d).csv >> /var/log/reorder.log 2>&1
+```
+
+## Reorder Log
+
+All API calls are stored in `reorder_log.db` in the same folder. Inspect the log with:
+
+```bash
+sqlite3 reorder_log.db "SELECT * FROM reorder_log ORDER BY timestamp DESC LIMIT 20;"
+```
+
+Run `report.py` after the pipeline to send the daily email summary.

--- a/ai_automation/cafe_inventory_autoreorder/forecast.py
+++ b/ai_automation/cafe_inventory_autoreorder/forecast.py
@@ -1,0 +1,45 @@
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+from statsmodels.tsa.holtwinters import SimpleExpSmoothing
+
+
+SAFETY_LEVEL = 10  # default safety stock if not overridden
+
+
+def read_history(path: Path) -> pd.DataFrame:
+    """Load POS history CSV (item_id, sold_qty, current_stock[, date])."""
+    df = pd.read_csv(path)
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+def forecast_depletion(df: pd.DataFrame, days: int = 14) -> pd.DataFrame:
+    """Return forecasted daily demand and stockout date for each SKU."""
+    results = []
+    today = date.today()
+    for item_id, group in df.groupby("item_id"):
+        group = group.sort_index()
+        sales = group["sold_qty"].astype(float)
+        current_stock = group["current_stock"].iloc[-1]
+        if len(sales) < 2:
+            daily = sales.iloc[-1]
+        else:
+            model = SimpleExpSmoothing(sales, initialization_method="heuristic")
+            fit = model.fit()
+            daily = float(fit.forecast(1).iloc[0])
+        predicted_stock = current_stock - daily * days
+        days_to_oos = current_stock / daily if daily > 0 else float("inf")
+        stockout_date = today + timedelta(days=int(days_to_oos)) if daily > 0 else None
+        results.append(
+            {
+                "item_id": item_id,
+                "predicted_daily_sales": daily,
+                "predicted_stock": predicted_stock,
+                "stockout_date": stockout_date,
+            }
+        )
+    return pd.DataFrame(results)

--- a/ai_automation/cafe_inventory_autoreorder/logger.py
+++ b/ai_automation/cafe_inventory_autoreorder/logger.py
@@ -1,0 +1,54 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path(__file__).parent / "reorder_log.db"
+
+
+def init_db(db_path: Path = DB_PATH) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS reorder_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT,
+            item_id TEXT,
+            quantity INTEGER,
+            status_code INTEGER,
+            response_body TEXT,
+            success INTEGER,
+            error TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_reorder(
+    item_id: str,
+    quantity: int,
+    status_code: Optional[int],
+    response_body: Optional[str],
+    success: bool,
+    error: Optional[str] = None,
+    db_path: Path = DB_PATH,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO reorder_log (timestamp, item_id, quantity, status_code, response_body, success, error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            datetime.utcnow().isoformat(),
+            item_id,
+            quantity,
+            status_code,
+            response_body,
+            int(success),
+            error,
+        ),
+    )
+    conn.commit()
+    conn.close()

--- a/ai_automation/cafe_inventory_autoreorder/reorder.py
+++ b/ai_automation/cafe_inventory_autoreorder/reorder.py
@@ -1,0 +1,65 @@
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import requests
+from dotenv import load_dotenv
+
+from forecast import read_history, forecast_depletion, SAFETY_LEVEL
+from logger import init_db, log_reorder
+
+load_dotenv()
+
+API_URL = os.environ.get("SUPPLIER_API_URL", "http://supplier.example.com")
+API_TOKEN = os.environ.get("SUPPLIER_API_TOKEN", "")
+SAFETY_LEVEL = int(os.environ.get("SAFETY_LEVEL", SAFETY_LEVEL))
+
+
+def place_order(sku: str, quantity: int) -> requests.Response:
+    url = f"{API_URL.rstrip('/')}/orders"
+    headers = {"Authorization": f"Bearer {API_TOKEN}", "Content-Type": "application/json"}
+    payload = {"sku": sku, "quantity": quantity}
+    response = requests.post(url, headers=headers, data=json.dumps(payload), timeout=10)
+    return response
+
+
+def process(csv_path: Path) -> pd.DataFrame:
+    df = read_history(csv_path)
+    forecast_df = forecast_depletion(df)
+
+    init_db()
+
+    for _, row in forecast_df.iterrows():
+        if row["predicted_stock"] < SAFETY_LEVEL:
+            reorder_qty = int(SAFETY_LEVEL * 2 - row["predicted_stock"])
+            try:
+                resp = place_order(row["item_id"], reorder_qty)
+                success = resp.status_code == 201
+                log_reorder(
+                    row["item_id"],
+                    reorder_qty,
+                    resp.status_code,
+                    resp.text,
+                    success,
+                )
+            except Exception as exc:
+                log_reorder(
+                    row["item_id"],
+                    reorder_qty,
+                    None,
+                    None,
+                    False,
+                    error=str(exc),
+                )
+    return forecast_df
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Auto reorder pipeline")
+    parser.add_argument("csv_path", type=Path, help="Path to POS CSV")
+    args = parser.parse_args()
+
+    process(args.csv_path)

--- a/ai_automation/cafe_inventory_autoreorder/report.py
+++ b/ai_automation/cafe_inventory_autoreorder/report.py
@@ -1,0 +1,68 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+from dotenv import load_dotenv
+
+from logger import DB_PATH
+
+load_dotenv()
+
+SMTP_SERVER = os.environ.get("SMTP_SERVER", "localhost")
+SMTP_PORT = int(os.environ.get("SMTP_PORT", 25))
+EMAIL_USER = os.environ.get("EMAIL_USER")
+EMAIL_PASS = os.environ.get("EMAIL_PASS")
+EMAIL_TO = os.environ.get("EMAIL_TO")
+
+
+def fetch_logs() -> pd.DataFrame:
+    if not DB_PATH.exists():
+        return pd.DataFrame()
+    return pd.read_sql("SELECT * FROM reorder_log", f"sqlite:///{DB_PATH}")
+
+
+def build_message(forecast_df: pd.DataFrame, log_df: pd.DataFrame) -> str:
+    reordered = log_df[log_df["success"] == 1]
+    exceptions = log_df[log_df["success"] == 0]
+
+    lines = ["Daily Inventory Auto-Reorder Report", ""]
+    lines.append("Items reordered:")
+    if not reordered.empty:
+        for _, row in reordered.iterrows():
+            lines.append(f"- {row['item_id']} qty {row['quantity']} status {row['status_code']}")
+    else:
+        lines.append("None")
+
+    lines.append("\nPredicted stock-out dates:")
+    for _, row in forecast_df.iterrows():
+        lines.append(f"- {row['item_id']}: {row['stockout_date']}")
+
+    if not exceptions.empty:
+        lines.append("\nExceptions:")
+        for _, row in exceptions.iterrows():
+            lines.append(f"- {row['item_id']} error: {row['error']}")
+
+    return "\n".join(lines)
+
+
+def send_email(subject: str, body: str) -> None:
+    msg = MIMEText(body)
+    msg["Subject"] = subject
+    msg["From"] = EMAIL_USER or "noreply@example.com"
+    msg["To"] = EMAIL_TO or ""
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+        if EMAIL_USER and EMAIL_PASS:
+            server.starttls()
+            server.login(EMAIL_USER, EMAIL_PASS)
+        server.send_message(msg)
+
+
+def send_daily_report(forecast_df: pd.DataFrame) -> None:
+    logs = fetch_logs()
+    message = build_message(forecast_df, logs)
+    send_email("Cafe Inventory Report", message)
+

--- a/ai_automation/cafe_inventory_autoreorder/requirements.txt
+++ b/ai_automation/cafe_inventory_autoreorder/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+statsmodels
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- add `cafe_inventory_autoreorder` example under `ai_automation`
- implement scripts for forecasting, ordering, logging and reporting
- document pipeline usage and environment variables
- list Python dependencies

## Testing
- `python -m py_compile ai_automation/cafe_inventory_autoreorder/*.py`
- `python ai_automation/cafe_inventory_autoreorder/reorder.py nonexistent.csv` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a1114bdec8327b7009b25760ba6b8