### PR TITLE
Add ice cream demand forecasting example

### DIFF
--- a/ai_automation/ice_cream_demand/README.md
+++ b/ai_automation/ice_cream_demand/README.md
@@ -1,0 +1,48 @@
+# Ice Cream Demand Forecasting
+
+This folder contains a small pipeline that merges historical ice cream sales with weather data to train a demand model and serve forecasts through a FastAPI service.
+
+## Files
+
+- `fetch_weather.py` – Downloads daily temperature and precipitation from the free [Open‑Meteo](https://open-meteo.com/) API.
+- `prepare_data.py` – Merges sales with weather, adds lag features and calendar flags.
+- `train.py` – Trains an XGBoost regressor and stores the model along with the last week of history.
+- `app.py` – FastAPI application exposing `/forecast?date=YYYY-MM-DD`.
+- `requirements.txt` – Python dependencies.
+
+## Weather → Sales Features
+
+The prepared dataset includes:
+
+- `lag1`, `lag7` – Units sold 1 and 7 days prior.
+- `day_of_week` – Numeric weekday indicator.
+- `is_holiday` – Boolean flag using US public holidays.
+- `temp_weekend` – Temperature multiplied by a weekend indicator.
+- Raw daily `temperature` and `precipitation`.
+
+These features capture short‑term trends and how warm weekends or holidays boost demand.
+
+## Model and Hyperparameters
+
+An `XGBRegressor` is trained with `objective="reg:squarederror"` and `n_estimators=200`. XGBoost handles nonlinear relationships and interactions between the engineered features.
+
+## Running the Pipeline
+
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Prepare a CSV `sales.csv` with columns `date`, `product`, `units_sold`, `location`.
+3. Train the model:
+   ```bash
+   python train.py sales.csv
+   ```
+4. Start the API server:
+   ```bash
+   uvicorn app:app --reload
+   ```
+5. Request a forecast starting from a date:
+   ```bash
+   curl 'http://localhost:8000/forecast?date=2024-07-01'
+   ```
+   The response contains seven predicted `units_sold` values for the upcoming week.

--- a/ai_automation/ice_cream_demand/app.py
+++ b/ai_automation/ice_cream_demand/app.py
@@ -1,0 +1,50 @@
+"""FastAPI service providing a 7-day demand forecast."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import joblib
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+import holidays
+
+from fetch_weather import fetch_weather
+from prepare_data import FEATURES
+
+MODEL_PATH = "model.pkl"
+HISTORY_PATH = "history.csv"
+
+app = FastAPI()
+model = joblib.load(MODEL_PATH)
+history = pd.read_csv(HISTORY_PATH)
+history["date"] = pd.to_datetime(history["date"])
+location = history["location"].iloc[-1]
+us_holidays = holidays.US()
+
+
+@app.get("/forecast")
+def forecast(date: str):
+    try:
+        start = pd.to_datetime(date)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date")
+
+    df = history.copy()
+    preds: list[float] = []
+    for i in range(7):
+        day = start + timedelta(days=i)
+        weather = fetch_weather(day.strftime("%Y-%m-%d"), day.strftime("%Y-%m-%d"), location).iloc[0]
+        row = {
+            "lag1": df["units_sold"].iloc[-1],
+            "lag7": df["units_sold"].iloc[-7],
+            "day_of_week": day.dayofweek,
+            "is_holiday": day.date() in us_holidays,
+            "temperature": weather["temperature"],
+            "precipitation": weather["precipitation"],
+        }
+        row["temp_weekend"] = row["temperature"] * (row["day_of_week"] >= 5)
+        pred = float(model.predict(pd.DataFrame([row])[FEATURES])[0])
+        preds.append(pred)
+        df = pd.concat([df, pd.DataFrame([{"date": day, "units_sold": pred}])], ignore_index=True)
+    return {"date": date, "predicted_units": preds}

--- a/ai_automation/ice_cream_demand/fetch_weather.py
+++ b/ai_automation/ice_cream_demand/fetch_weather.py
@@ -1,0 +1,51 @@
+"""Fetch daily weather data from a public API."""
+
+from __future__ import annotations
+
+import requests
+import pandas as pd
+
+# Example mapping of location name to latitude and longitude.
+# Extend this dictionary with the locations in your sales CSV.
+LOCATION_COORDS = {
+    "new_york": (40.7128, -74.0060),
+    "los_angeles": (34.0522, -118.2437),
+}
+
+
+def fetch_weather(start_date: str, end_date: str, location: str) -> pd.DataFrame:
+    """Return daily temperature and precipitation for the date range.
+
+    Parameters
+    ----------
+    start_date: str
+        First date in ``YYYY-MM-DD`` format.
+    end_date: str
+        Last date in ``YYYY-MM-DD`` format.
+    location: str
+        Key in ``LOCATION_COORDS`` specifying the city.
+    """
+    if location not in LOCATION_COORDS:
+        raise ValueError(f"Unknown location: {location}")
+
+    lat, lon = LOCATION_COORDS[location]
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "start_date": start_date,
+        "end_date": end_date,
+        "daily": "temperature_2m_max,precipitation_sum",
+        "timezone": "UTC",
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()["daily"]
+    df = pd.DataFrame({
+        "date": data["time"],
+        "temperature": data["temperature_2m_max"],
+        "precipitation": data["precipitation_sum"],
+    })
+    df["date"] = pd.to_datetime(df["date"])
+    df["location"] = location
+    return df

--- a/ai_automation/ice_cream_demand/prepare_data.py
+++ b/ai_automation/ice_cream_demand/prepare_data.py
@@ -1,0 +1,64 @@
+"""Merge sales with weather and engineer features."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import holidays
+
+from fetch_weather import fetch_weather
+
+FEATURES = [
+    "lag1",
+    "lag7",
+    "day_of_week",
+    "is_holiday",
+    "temperature",
+    "precipitation",
+    "temp_weekend",
+]
+
+
+def _load_sales(csv_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(csv_path)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+def _fetch_weather_for_sales(df: pd.DataFrame) -> pd.DataFrame:
+    start = df["date"].min().strftime("%Y-%m-%d")
+    end = df["date"].max().strftime("%Y-%m-%d")
+    frames = [fetch_weather(start, end, loc) for loc in df["location"].unique()]
+    weather = pd.concat(frames)
+    return df.merge(weather, on=["date", "location"], how="left")
+
+
+def _add_features(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values(["location", "product", "date"])
+    df["lag1"] = df.groupby(["product", "location"])["units_sold"].shift(1)
+    df["lag7"] = df.groupby(["product", "location"])["units_sold"].shift(7)
+    df["day_of_week"] = df["date"].dt.dayofweek
+    us_holidays = holidays.US()
+    df["is_holiday"] = df["date"].dt.date.isin(us_holidays)
+    df["is_weekend"] = df["day_of_week"] >= 5
+    df["temp_weekend"] = df["temperature"] * df["is_weekend"]
+    df = df.dropna(subset=["lag1", "lag7"])
+    return df
+
+
+def prepare_dataset(csv_path: str | Path) -> pd.DataFrame:
+    sales = _load_sales(Path(csv_path))
+    merged = _fetch_weather_for_sales(sales)
+    return _add_features(merged)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python prepare_data.py sales.csv")
+        sys.exit(1)
+    prepared = prepare_dataset(sys.argv[1])
+    prepared.to_csv("prepared.csv", index=False)
+    print("Prepared data written to prepared.csv")

--- a/ai_automation/ice_cream_demand/requirements.txt
+++ b/ai_automation/ice_cream_demand/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+requests
+xgboost
+scikit-learn
+holidays
+fastapi
+uvicorn
+joblib

--- a/ai_automation/ice_cream_demand/train.py
+++ b/ai_automation/ice_cream_demand/train.py
@@ -1,0 +1,34 @@
+"""Train an XGBoost model to forecast ice cream demand."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from xgboost import XGBRegressor
+
+from prepare_data import prepare_dataset, FEATURES
+
+MODEL_PATH = Path("model.pkl")
+HISTORY_PATH = Path("history.csv")
+
+
+def train_model(csv_path: str | Path) -> None:
+    df = prepare_dataset(csv_path)
+    df = df.sort_values("date")
+    X = df[FEATURES]
+    y = df["units_sold"]
+    model = XGBRegressor(objective="reg:squarederror", n_estimators=200)
+    model.fit(X, y)
+    joblib.dump(model, MODEL_PATH)
+    df.tail(7).to_csv(HISTORY_PATH, index=False)
+    print("Model saved to", MODEL_PATH)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python train.py sales.csv")
+        sys.exit(1)
+    train_model(sys.argv[1])


### PR DESCRIPTION
## Summary
- create `ice_cream_demand` folder under `ai_automation`
- implement weather fetcher using Open‑Meteo
- prepare dataset with lags, holidays and weather features
- train XGBoost regression model and save last week of history
- expose `/forecast` endpoint through FastAPI
- document pipeline and usage in README

## Testing
- `python -m py_compile ai_automation/ice_cream_demand/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a110c15ec8327b9a966cdc0c49162