### PR TITLE
Add actuarial pricing example

### DIFF
--- a/ai_automation/actuarial_pricing/README.md
+++ b/ai_automation/actuarial_pricing/README.md
@@ -1,0 +1,43 @@
+# Actuarial Pricing Example
+
+This package demonstrates a very small actuarial pricing workflow. It loads
+policyholder profiles and a mortality table, prices each policy using a simple
+present value formula and outputs a PDF summary report.
+
+## Data
+
+Two CSV files are required:
+
+1. **Policyholder profiles** – columns
+   `policy_id`, `age`, `gender`, `sum_insured`, `smoker_flag`,
+   `coverage_term_years`.
+2. **Mortality table** – columns `age`, `q_x` where `q_x` is the mortality rate
+   for that age. Any standard table may be used.
+
+The example assumes the interest rate and loading percentages defined in
+`config.py`. Adjust these values as needed.
+
+## Usage
+
+Install dependencies and run the pricing workflow:
+
+```bash
+pip install -r requirements.txt
+```
+
+```python
+import pandas as pd
+from actuarial_pricing import load_data, pricing, report
+from actuarial_pricing.config import interest_rate, expense_loading, profit_loading
+
+policies = load_data.load_policyholders("policyholders.csv")
+mort_table = load_data.load_mortality_table("mortality.csv")
+
+priced = pricing.price_policies(policies, mort_table)
+priced.to_csv("priced_policies.csv", index=False)
+
+report.generate_pdf(priced.join(policies[["age"]]), "premium_report.pdf")
+```
+
+The resulting PDF shows total gross premium by 5‑year age bands.
+Modify the values in `config.py` to change the interest rate or loadings.

--- a/ai_automation/actuarial_pricing/__init__.py
+++ b/ai_automation/actuarial_pricing/__init__.py
@@ -1,0 +1,9 @@
+"""Actuarial pricing package."""
+
+__all__ = [
+    "load_data",
+    "pricing",
+    "report",
+    "config",
+    "utils",
+]

--- a/ai_automation/actuarial_pricing/config.py
+++ b/ai_automation/actuarial_pricing/config.py
@@ -1,0 +1,10 @@
+"""Configuration values for the actuarial pricing package."""
+
+# Annual interest rate used for discounting
+interest_rate = 0.03
+
+# Expense loading applied as a percentage of net premium
+expense_loading = 0.1  # 10%
+
+# Profit loading applied as a percentage of net premium
+profit_loading = 0.05  # 5%

--- a/ai_automation/actuarial_pricing/load_data.py
+++ b/ai_automation/actuarial_pricing/load_data.py
@@ -1,0 +1,36 @@
+"""CSV ingestion helpers."""
+
+from pathlib import Path
+import pandas as pd
+
+from .utils import DataLoadError
+
+
+POLICY_COLS = [
+    "policy_id",
+    "age",
+    "gender",
+    "sum_insured",
+    "smoker_flag",
+    "coverage_term_years",
+]
+
+MORTALITY_COLS = ["age", "q_x"]
+
+
+def load_policyholders(csv_path: Path | str) -> pd.DataFrame:
+    """Load policyholder profiles from a CSV file."""
+    try:
+        df = pd.read_csv(csv_path, usecols=POLICY_COLS)
+    except Exception as exc:  # broad catch to wrap errors
+        raise DataLoadError(f"Could not load policyholder data: {exc}") from exc
+    return df
+
+
+def load_mortality_table(csv_path: Path | str) -> pd.DataFrame:
+    """Load mortality table CSV."""
+    try:
+        df = pd.read_csv(csv_path, usecols=MORTALITY_COLS)
+    except Exception as exc:
+        raise DataLoadError(f"Could not load mortality table: {exc}") from exc
+    return df.set_index("age")

--- a/ai_automation/actuarial_pricing/pricing.py
+++ b/ai_automation/actuarial_pricing/pricing.py
@@ -1,0 +1,57 @@
+"""Premium calculation utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from .config import interest_rate, expense_loading, profit_loading
+from .utils import PricingError
+
+
+def lookup_q(age: int, mortality_table: pd.DataFrame) -> float:
+    """Return mortality rate q_x for given age."""
+    try:
+        return float(mortality_table.loc[age, "q_x"])
+    except KeyError as exc:
+        raise PricingError(f"No mortality rate for age {age}") from exc
+
+
+def net_premium(age: int, sum_insured: float, term: int, mortality_table: pd.DataFrame) -> float:
+    """Calculate net premium using simple actuarial present value formula."""
+    v = 1 / (1 + interest_rate)
+    premiums = []
+    for t in range(1, term + 1):
+        q = lookup_q(age + t - 1, mortality_table)
+        premiums.append(q * v**t)
+    return sum_insured * float(np.sum(premiums))
+
+
+def gross_premium(net: float) -> float:
+    """Apply expense and profit loadings to net premium."""
+    loading_factor = 1 + expense_loading + profit_loading
+    return net * loading_factor
+
+
+def price_policies(
+    policies: pd.DataFrame,
+    mortality_table: pd.DataFrame,
+) -> pd.DataFrame:
+    """Return premiums for each policy."""
+    results = []
+    for _, row in policies.iterrows():
+        net = net_premium(
+            age=int(row["age"]),
+            sum_insured=float(row["sum_insured"]),
+            term=int(row["coverage_term_years"]),
+            mortality_table=mortality_table,
+        )
+        gross = gross_premium(net)
+        results.append(
+            {
+                "policy_id": row["policy_id"],
+                "net_premium": net,
+                "gross_premium": gross,
+            }
+        )
+    return pd.DataFrame(results)

--- a/ai_automation/actuarial_pricing/report.py
+++ b/ai_automation/actuarial_pricing/report.py
@@ -1,0 +1,33 @@
+"""PDF reporting utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+from jinja2 import Environment, FileSystemLoader, Template
+from weasyprint import HTML
+
+
+def _build_html(df: pd.DataFrame) -> str:
+    """Render HTML using a very small inline template."""
+    age_bins = (df["age"] // 5) * 5
+    summary = df.assign(age_band=age_bins).groupby("age_band")["gross_premium"].sum()
+    env = Environment(autoescape=True)
+    template = Template(
+        """
+        <h1>Premium Summary</h1>
+        <table border="1" cellspacing="0" cellpadding="4">
+            <tr><th>Age Band</th><th>Total Gross Premium</th></tr>
+            {% for band, total in summary.items() %}
+            <tr><td>{{ band }}-{{ band + 4 }}</td><td>{{ '{:.2f}'.format(total) }}</td></tr>
+            {% endfor %}
+        </table>
+        """
+    )
+    return template.render(summary=summary)
+
+
+def generate_pdf(df: pd.DataFrame, output_path: Path | str) -> None:
+    """Generate a PDF summary report."""
+    html = _build_html(df)
+    HTML(string=html).write_pdf(str(output_path))

--- a/ai_automation/actuarial_pricing/requirements.txt
+++ b/ai_automation/actuarial_pricing/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+scipy
+jinja2
+weasyprint

--- a/ai_automation/actuarial_pricing/utils.py
+++ b/ai_automation/actuarial_pricing/utils.py
@@ -1,0 +1,19 @@
+"""Utility helpers for logging and exceptions."""
+
+import logging
+
+
+class PricingError(Exception):
+    """Base class for pricing related errors."""
+
+
+class DataLoadError(PricingError):
+    """Raised when input data cannot be loaded."""
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure basic logging for the package."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )


### PR DESCRIPTION
## Summary
- add actuarial_pricing package with CSV loading, pricing and report utilities
- document usage and configuration

## Testing
- `python -m py_compile ai_automation/actuarial_pricing/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a12098dec83279643d6fa7aa82ee9