### PR TITLE
Add SQL Data Management PWA skeleton

### DIFF
--- a/SQL Data Management/.replit
+++ b/SQL Data Management/.replit
@@ -1,0 +1,1 @@
+run = "pip install -r requirements.txt && python scripts/import_cards.py && python app.py"

--- a/SQL Data Management/app.py
+++ b/SQL Data Management/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, send_from_directory
+from flask_migrate import Migrate
+from flask_jwt_extended import JWTManager
+from flask_cors import CORS
+from models import db
+from config import Config
+import os
+
+
+def create_app():
+    app = Flask(__name__, static_folder='static', template_folder='templates')
+    app.config.from_object(Config)
+
+    db.init_app(app)
+    Migrate(app, db)
+    JWTManager(app)
+    CORS(app, resources={r"/*": {"origins": app.config.get('CORS_ORIGINS')}})
+
+    from routes.auth import auth_bp
+    from routes.cards import cards_bp
+    from routes.transactions import transactions_bp
+    from routes.messages import messages_bp
+    from routes.battles import battles_bp
+    from routes.admin import admin_bp
+
+    app.register_blueprint(auth_bp, url_prefix='/auth')
+    app.register_blueprint(cards_bp, url_prefix='/cards')
+    app.register_blueprint(transactions_bp, url_prefix='/transactions')
+    app.register_blueprint(messages_bp, url_prefix='/messages')
+    app.register_blueprint(battles_bp, url_prefix='/battles')
+    app.register_blueprint(admin_bp, url_prefix='/admin')
+
+    os.makedirs(os.path.join(os.path.dirname(__file__), 'data'), exist_ok=True)
+
+    @app.route('/')
+    def index():
+        return send_from_directory('templates', 'index.html')
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/SQL Data Management/config.py
+++ b/SQL Data Management/config.py
@@ -1,0 +1,10 @@
+import os
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'data', 'app.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'super-secret-key')
+    JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'jwt-secret-key')
+    CORS_ORIGINS = '*'

--- a/SQL Data Management/manifest.json
+++ b/SQL Data Management/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "SQL Data Management",
+  "short_name": "SQLData",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Pokémon card trading platform",
+  "icons": []
+}

--- a/SQL Data Management/models.py
+++ b/SQL Data Management/models.py
@@ -1,0 +1,73 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    tokens = db.Column(db.Integer, default=500)
+    is_admin = db.Column(db.Boolean, default=False)
+
+    cards = db.relationship('UserCard', backref='user', lazy=True)
+    sent_messages = db.relationship('Message', foreign_keys='Message.sender_id', backref='sender', lazy=True)
+    received_messages = db.relationship('Message', foreign_keys='Message.recipient_id', backref='recipient', lazy=True)
+    decks = db.relationship('Deck', backref='user', lazy=True)
+
+
+class Card(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    api_id = db.Column(db.String(80), unique=True, nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    image_url = db.Column(db.String(255))
+    attack = db.Column(db.Integer)
+    defense = db.Column(db.Integer)
+    hp = db.Column(db.Integer)
+
+
+class UserCard(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    card_id = db.Column(db.Integer, db.ForeignKey('card.id'), nullable=False)
+    quantity = db.Column(db.Integer, default=1)
+
+    card = db.relationship('Card', backref='user_cards')
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    buyer_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    seller_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    card_id = db.Column(db.Integer, db.ForeignKey('card.id'), nullable=False)
+    quantity = db.Column(db.Integer, default=1)
+    price_per_card = db.Column(db.Integer)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Message(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    body = db.Column(db.Text)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Deck(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    is_active = db.Column(db.Boolean, default=False)
+
+    cards = db.relationship('DeckCard', backref='deck', lazy=True)
+
+
+class DeckCard(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    deck_id = db.Column(db.Integer, db.ForeignKey('deck.id'), nullable=False)
+    card_id = db.Column(db.Integer, db.ForeignKey('card.id'), nullable=False)
+    quantity = db.Column(db.Integer, default=1)
+
+    card = db.relationship('Card')

--- a/SQL Data Management/requirements.txt
+++ b/SQL Data Management/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask_sqlalchemy
+flask_migrate
+flask_jwt_extended
+flask_cors
+requests

--- a/SQL Data Management/routes/admin.py
+++ b/SQL Data Management/routes/admin.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from models import db, User, Card, Transaction, Message, Deck
+
+admin_bp = Blueprint('admin', __name__)
+
+
+def admin_required(func):
+    @jwt_required()
+    def wrapper(*args, **kwargs):
+        user = User.query.get(get_jwt_identity())
+        if not user or not user.is_admin:
+            return jsonify({'msg': 'admin only'}), 403
+        return func(*args, **kwargs)
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+
+@admin_bp.route('/users', methods=['GET'])
+@admin_required
+def all_users():
+    users = User.query.all()
+    data = [{'id': u.id, 'username': u.username} for u in users]
+    return jsonify(data)
+
+# TODO: add CRUD endpoints for other models

--- a/SQL Data Management/routes/auth.py
+++ b/SQL Data Management/routes/auth.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, request, jsonify
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
+from models import db, User, Deck
+import random
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json()
+    username = data.get('username')
+    email = data.get('email')
+    password = data.get('password')
+
+    if User.query.filter((User.username == username) | (User.email == email)).first():
+        return jsonify({'msg': 'User exists'}), 400
+
+    user = User(username=username, email=email, password_hash=generate_password_hash(password))
+    db.session.add(user)
+    db.session.commit()
+
+    # TODO: assign random starter deck
+    return jsonify({'msg': 'registered'}), 201
+
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()
+    username = data.get('username')
+    password = data.get('password')
+
+    user = User.query.filter_by(username=username).first()
+    if not user or not check_password_hash(user.password_hash, password):
+        return jsonify({'msg': 'Bad credentials'}), 401
+
+    token = create_access_token(identity=user.id)
+    return jsonify(access_token=token)
+
+
+@auth_bp.route('/protected')
+@jwt_required()
+def protected():
+    user_id = get_jwt_identity()
+    return jsonify(id=user_id)

--- a/SQL Data Management/routes/battles.py
+++ b/SQL Data Management/routes/battles.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+battles_bp = Blueprint('battles', __name__)
+
+
+@battles_bp.route('/duel', methods=['POST'])
+@jwt_required()
+def duel():
+    # TODO: implement duel logic
+    return jsonify({'msg': 'duel - TODO'})
+
+
+@battles_bp.route('/royale', methods=['POST'])
+@jwt_required()
+def royale():
+    # TODO: implement battle royale logic
+    return jsonify({'msg': 'royale - TODO'})

--- a/SQL Data Management/routes/cards.py
+++ b/SQL Data Management/routes/cards.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, jsonify
+from models import Card
+from scripts.import_cards import fetch_cards, upsert_cards
+
+cards_bp = Blueprint('cards', __name__)
+
+
+@cards_bp.route('/import', methods=['POST'])
+def import_cards():
+    cards = fetch_cards()
+    upsert_cards(cards)
+    return jsonify({'msg': 'cards imported'})
+
+
+@cards_bp.route('/', methods=['GET'])
+def list_cards():
+    cards = Card.query.all()
+    data = [{'id': c.id, 'name': c.name, 'image_url': c.image_url} for c in cards]
+    return jsonify(data)

--- a/SQL Data Management/routes/messages.py
+++ b/SQL Data Management/routes/messages.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from models import db, Message
+
+messages_bp = Blueprint('messages', __name__)
+
+
+@messages_bp.route('/', methods=['POST'])
+@jwt_required()
+def send_message():
+    user_id = get_jwt_identity()
+    data = request.get_json()
+    msg = Message(sender_id=user_id, recipient_id=data['recipient_id'], body=data['body'])
+    db.session.add(msg)
+    db.session.commit()
+    return jsonify({'msg': 'sent'})
+
+
+@messages_bp.route('/', methods=['GET'])
+@jwt_required()
+def inbox():
+    user_id = get_jwt_identity()
+    messages = Message.query.filter_by(recipient_id=user_id).all()
+    data = [{'id': m.id, 'from': m.sender_id, 'body': m.body} for m in messages]
+    return jsonify(data)

--- a/SQL Data Management/routes/transactions.py
+++ b/SQL Data Management/routes/transactions.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from models import db, User, Card, UserCard, Transaction
+
+transactions_bp = Blueprint('transactions', __name__)
+
+
+@transactions_bp.route('/list', methods=['POST'])
+@jwt_required()
+def list_for_sale():
+    # TODO: implement listing of card for sale
+    return jsonify({'msg': 'list for sale - TODO'})
+
+
+@transactions_bp.route('/marketplace', methods=['GET'])
+@jwt_required(optional=True)
+def view_marketplace():
+    # TODO: return marketplace listings
+    return jsonify([])
+
+
+@transactions_bp.route('/buy', methods=['POST'])
+@jwt_required()
+def buy_card():
+    # TODO: implement buying logic
+    return jsonify({'msg': 'buy card - TODO'})

--- a/SQL Data Management/scripts/import_cards.py
+++ b/SQL Data Management/scripts/import_cards.py
@@ -1,0 +1,37 @@
+import os
+import requests
+from models import db, Card
+from flask import Flask
+from config import Config
+
+app = Flask(__name__)
+app.config.from_object(Config)
+db.init_app(app)
+
+
+def fetch_cards():
+    url = 'https://api.pokemontcg.io/v2/cards'
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json().get('data', [])
+
+
+def upsert_cards(cards):
+    with app.app_context():
+        for c in cards:
+            card = Card.query.filter_by(api_id=c['id']).first()
+            if not card:
+                card = Card(api_id=c['id'])
+            card.name = c['name']
+            card.image_url = c.get('images', {}).get('small')
+            attacks = c.get('attacks', [])
+            card.attack = attacks[0]['damage'] if attacks else 0
+            card.defense = 0  # TODO: derive defense
+            card.hp = int(c.get('hp', 0)) if c.get('hp') else 0
+            db.session.add(card)
+        db.session.commit()
+
+
+if __name__ == '__main__':
+    cards = fetch_cards()
+    upsert_cards(cards)

--- a/SQL Data Management/service-worker.js
+++ b/SQL Data Management/service-worker.js
@@ -1,0 +1,16 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('static-v1').then(cache => cache.addAll([
+      '/',
+      '/static/css/styles.css',
+      '/static/js/main.js',
+      '/manifest.json'
+    ]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/SQL Data Management/static/css/styles.css
+++ b/SQL Data Management/static/css/styles.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+nav { background: #333; padding: 10px; }
+nav a { color: white; margin-right: 10px; text-decoration: none; }
+#content { padding: 20px; }

--- a/SQL Data Management/static/js/main.js
+++ b/SQL Data Management/static/js/main.js
@@ -1,0 +1,4 @@
+// Basic frontend JS placeholder
+console.log('PWA loaded');
+
+// TODO: implement fetch helpers with JWT tokens

--- a/SQL Data Management/templates/admin.html
+++ b/SQL Data Management/templates/admin.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Admin Dashboard</h2>
+<div id="admin"></div>
+{% endblock %}

--- a/SQL Data Management/templates/battle.html
+++ b/SQL Data Management/templates/battle.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Battle</h2>
+<div id="battle"></div>
+{% endblock %}

--- a/SQL Data Management/templates/deck.html
+++ b/SQL Data Management/templates/deck.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Your Deck</h2>
+<div id="deck"></div>
+{% endblock %}

--- a/SQL Data Management/templates/index.html
+++ b/SQL Data Management/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Welcome to SQL Data Management</h1>
+<a href="/marketplace">Marketplace</a>
+{% endblock %}

--- a/SQL Data Management/templates/layout.html
+++ b/SQL Data Management/templates/layout.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="manifest" href="/manifest.json">
+    <title>SQL Data Management</title>
+</head>
+<body>
+<nav>
+    <a href="/">Home</a>
+    <a href="/login">Login</a>
+    <a href="/register">Register</a>
+</nav>
+<div id="content">
+    {% block content %}{% endblock %}
+</div>
+<script src="/static/js/main.js"></script>
+<script>
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js');
+}
+</script>
+</body>
+</html>

--- a/SQL Data Management/templates/login.html
+++ b/SQL Data Management/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Login</h2>
+<form id="login-form">
+    <input name="username" placeholder="Username">
+    <input name="password" type="password" placeholder="Password">
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/SQL Data Management/templates/marketplace.html
+++ b/SQL Data Management/templates/marketplace.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Marketplace</h2>
+<div id="marketplace"></div>
+{% endblock %}

--- a/SQL Data Management/templates/messages.html
+++ b/SQL Data Management/templates/messages.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Messages</h2>
+<div id="messages"></div>
+{% endblock %}

--- a/SQL Data Management/templates/register.html
+++ b/SQL Data Management/templates/register.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Register</h2>
+<form id="register-form">
+    <input name="username" placeholder="Username">
+    <input name="email" placeholder="Email">
+    <input name="password" type="password" placeholder="Password">
+    <button type="submit">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create new `SQL Data Management` folder
- add Flask app, models, config and routes skeleton
- include templates and static files for PWA
- configure service worker and Replit run command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b13af544483279481f2bae6a20e4b