### PR TITLE
Fix login pages and JS

### DIFF
--- a/SQL Data Management/static/css/styles.css
+++ b/SQL Data Management/static/css/styles.css
@@ -39,6 +39,10 @@ nav a {
     margin: auto;
 }
 
+.error {
+    border-color: red;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/SQL Data Management/static/js/main.js
+++ b/SQL Data Management/static/js/main.js
@@ -1,15 +1,15 @@
 // Basic frontend JS
 console.log('PWA loaded');
 
-export function showSpinner() {
+function showSpinner() {
   document.querySelectorAll('.spinner').forEach(el => el.style.display = 'block');
 }
 
-export function hideSpinner() {
+function hideSpinner() {
   document.querySelectorAll('.spinner').forEach(el => el.style.display = 'none');
 }
 
-export function validateForm(form) {
+function validateForm(form) {
   for (const input of form.querySelectorAll('input[required]')) {
     if (!input.value) {
       input.classList.add('error');

--- a/SQL Data Management/templates/login.html
+++ b/SQL Data Management/templates/login.html
@@ -2,8 +2,32 @@
 {% block content %}
 <h2>Login</h2>
 <form id="login-form">
-    <input name="username" placeholder="Username">
-    <input name="password" type="password" placeholder="Password">
+    <input name="username" placeholder="Username" required>
+    <input name="password" type="password" placeholder="Password" required>
     <button type="submit">Login</button>
 </form>
+<p id="login-msg"></p>
+<script>
+const form = document.getElementById('login-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!window.validateForm || !validateForm(form)) return;
+    const data = Object.fromEntries(new FormData(form).entries());
+    const resp = await fetch('/auth/login', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    });
+    const msg = document.getElementById('login-msg');
+    if (resp.ok) {
+        const json = await resp.json();
+        localStorage.setItem('token', json.access_token);
+        msg.style.color = 'green';
+        msg.textContent = 'Login successful';
+    } else {
+        msg.style.color = 'red';
+        msg.textContent = 'Login failed';
+    }
+});
+</script>
 {% endblock %}

--- a/SQL Data Management/templates/register.html
+++ b/SQL Data Management/templates/register.html
@@ -2,9 +2,31 @@
 {% block content %}
 <h2>Register</h2>
 <form id="register-form">
-    <input name="username" placeholder="Username">
-    <input name="email" placeholder="Email">
-    <input name="password" type="password" placeholder="Password">
+    <input name="username" placeholder="Username" required>
+    <input name="email" placeholder="Email" required>
+    <input name="password" type="password" placeholder="Password" required>
     <button type="submit">Register</button>
 </form>
+<p id="register-msg"></p>
+<script>
+const form = document.getElementById('register-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!window.validateForm || !validateForm(form)) return;
+    const data = Object.fromEntries(new FormData(form).entries());
+    const resp = await fetch('/auth/register', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    });
+    const msg = document.getElementById('register-msg');
+    if (resp.ok) {
+        msg.style.color = 'green';
+        msg.textContent = 'Registered';
+    } else {
+        msg.style.color = 'red';
+        msg.textContent = 'Registration failed';
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- mark login/register inputs as required
- add error styling for forms
- add frontend scripts for login and registration
- remove ES module exports from JS

## Testing
- `python -m compileall 'SQL Data Management'`

------
https://chatgpt.com/codex/tasks/task_e_684b5fed46bc83279e1730375615c857