### PR TITLE
Add Module 12 automation exercises

### DIFF
--- a/module_12/01_file_organization/README.md
+++ b/module_12/01_file_organization/README.md
@@ -1,0 +1,10 @@
+# File Organization Automation
+
+**Objective:**  
+Create a Python script that:
+- Scans a source directory for files by extension (e.g. `.txt`, `.jpg`, `.pdf`)
+- Creates subfolders (`text/`, `images/`, `pdfs/`) if they don’t exist
+- Moves each file into its appropriate folder
+
+**Codex Prompt:**  
+“Generate a Python script using `pathlib` that organizes all files in `~/Downloads` into subdirectories based on file extension (e.g. text/, images/, pdfs/). Ensure it creates the target folders if missing and logs each move to the console.”

--- a/module_12/02_data_extraction/README.md
+++ b/module_12/02_data_extraction/README.md
@@ -1,0 +1,10 @@
+# Multi-Source Data Extraction
+
+**Objective:**  
+Build a reusable Python module that:
+- Connects to a REST API (JSON) and a local SQLite database
+- Extracts data from both sources
+- Normalizes into a single Pandas DataFrame
+
+**Codex Prompt:**  
+“Write a Python module with two functions: `fetch_api_data()` (uses `requests` to GET JSON from `https://api.example.com/data`) and `fetch_db_data()` (uses `sqlite3` to SELECT rows from `data.db`). Combine results into a Pandas DataFrame and return it.”

--- a/module_12/03_data_entry/README.md
+++ b/module_12/03_data_entry/README.md
@@ -1,0 +1,10 @@
+# Automated Data Entry
+
+**Objective:**  
+Automate filling a web form at `http://example.com/form` with Selenium:
+- Read entries from `input.csv`
+- For each row, navigate to the form, fill fields `name`, `email`, `age`, and submit
+- Log successes and failures
+
+**Codex Prompt:**  
+“Generate a Python script using `selenium.webdriver.Chrome` that reads `input.csv`, iterates rows, opens `http://example.com/form`, fills `name`, `email`, `age`, clicks submit, and logs status.”

--- a/module_12/04_csv_excel/README.md
+++ b/module_12/04_csv_excel/README.md
@@ -1,0 +1,10 @@
+# CSV & Excel Automation
+
+**Objective:**  
+Write a script that:
+- Reads `sales.csv` into Pandas
+- Performs simple aggregation (total, average per region)
+- Exports the result to `summary.xlsx` with two worksheets: “raw” and “summary”
+
+**Codex Prompt:**  
+“Create a Python script using Pandas that reads `sales.csv`, computes total and average sales by region, then writes both the original data and the aggregated summary into `summary.xlsx`, each on its own sheet.”

--- a/module_12/05_pdf_manipulation/README.md
+++ b/module_12/05_pdf_manipulation/README.md
@@ -1,0 +1,10 @@
+# PDF Manipulation
+
+**Objective:**  
+Automate PDF tasks:
+- Extract all text from `report.pdf`
+- Split each page into a separate PDF (`page_1.pdf`, etc.)
+- Merge `appendix.pdf` at the end
+
+**Codex Prompt:**  
+“Write a Python script using PyPDF2 that reads `report.pdf`, extracts its text to `report.txt`, splits each page into `page_#.pdf`, then appends all pages of `appendix.pdf` to the end of a new `combined.pdf`.”

--- a/module_12/06_email_automation/README.md
+++ b/module_12/06_email_automation/README.md
@@ -1,0 +1,10 @@
+# Email Automation
+
+**Objective:**  
+Send a daily summary email:
+- Read `summary.xlsx`
+- Attach it to an email
+- Send via `smtplib` from `me@example.com` to a list of recipients
+
+**Codex Prompt:**  
+“Generate a Python script that uses `smtplib` and `email.mime` to send `summary.xlsx` as an attachment. Use SMTP server `smtp.example.com`, authenticate with environment variables, and send to multiple recipients.”

--- a/module_12/07_web_scraping/README.md
+++ b/module_12/07_web_scraping/README.md
@@ -1,0 +1,10 @@
+# Web Scraping for Data Collection
+
+**Objective:**  
+Scrape product data:
+- Crawl `https://example.com/products`
+- Extract product `name`, `price`, and `URL`
+- Save results to `products.csv`
+
+**Codex Prompt:**  
+“Write a Python script using `requests` and `BeautifulSoup` that fetches `https://example.com/products`, parses the product list to extract name, price, and link, and writes them to `products.csv`.”

--- a/module_12/08_database_automation/README.md
+++ b/module_12/08_database_automation/README.md
@@ -1,0 +1,10 @@
+# Database Automation
+
+**Objective:**  
+Automate data load:
+- Read `data.csv`
+- Upsert rows into PostgreSQL table `public.data_table`
+- Use `psycopg2` with transactions and parameterized queries
+
+**Codex Prompt:**  
+“Create a Python script using `psycopg2` that reads `data.csv` with Pandas and upserts each row into a PostgreSQL `data_table`. Use `ON CONFLICT` for upsert behavior and commit per batch of 100 rows.”

--- a/module_12/09_api_integration/README.md
+++ b/module_12/09_api_integration/README.md
@@ -1,0 +1,9 @@
+# API Integration
+
+**Objective:**  
+Fetch external data and push to your service:
+- GET weather data from OpenWeatherMap API
+- POST transformed JSON to your internal endpoint
+
+**Codex Prompt:**  
+“Generate a Python script that retrieves current weather for a city using the OpenWeatherMap API, transforms the JSON to only include `temp`, `humidity`, and `description`, then posts it to `https://internal.example.com/ingest` via `requests`.”

--- a/module_12/10_data_cleaning/README.md
+++ b/module_12/10_data_cleaning/README.md
@@ -1,0 +1,10 @@
+# Data Cleaning Automation
+
+**Objective:**  
+Automate cleaning of `raw_data.csv`:
+- Remove rows with more than 20% missing values
+- Standardize date columns to ISO format
+- Deduplicate on a composite key
+
+**Codex Prompt:**  
+“Write a Python script using Pandas that loads `raw_data.csv`, drops rows with >20% NA, converts any `date_` columns to ISO (`YYYY-MM-DD`), removes duplicate rows based on `id` and `timestamp`, and writes cleaned data to `cleaned.csv`.”


### PR DESCRIPTION
## Summary
- add ten learning module directories under `module_12`
- include README prompts for exercises like file organization, API integration, and more

## Testing
- `pytest -q` *(fails: pandas, twilio missing)*

------
https://chatgpt.com/codex/tasks/task_e_685077980c548327b13550ee5be10c28