### PR TITLE
Add Pokémon data warehousing examples

### DIFF
--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/README.md
@@ -1,0 +1,2 @@
+# battle_statistics_real_time
+Real-time battle data provides insight into strategies and move popularity. This directory contains a stub for ingesting live battle logs and appending them to a data store. By continuously collecting records we can analyze trends as they happen. The example uses a placeholder loop or messaging system to simulate streaming ingestion.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/example.py
@@ -1,0 +1,4 @@
+import time
+
+# TODO: Simulate real-time ingestion of battle logs
+# TODO: Append incoming records to a table or DataFrame

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/README.md
@@ -1,0 +1,2 @@
+# cloud_vs_onprem_pokedex
+Choosing where to host a Pokédex warehouse involves balancing scalability and control. This folder compares connecting to a cloud data warehouse like AWS Redshift versus an on-prem PostgreSQL instance. Running the same query on both illustrates differences in setup and performance. It also highlights the trade-offs between managed and self-hosted solutions.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/example.py
@@ -1,0 +1,5 @@
+# Placeholder imports for database connections
+import sqlalchemy
+
+# TODO: Outline connections to AWS Redshift and local PostgreSQL
+# TODO: Run the same query against each warehouse and compare results

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/README.md
@@ -1,0 +1,2 @@
+# generation_partitioned_table
+Each generation of Pokémon introduces new species and mechanics. This example demonstrates storing Pokémon data in Parquet files partitioned by generation for efficient queries. Analysts can quickly load a single generation without scanning the entire dataset. Partitioning also keeps storage manageable as new generations are released.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Write Pokémon data to Parquet partitioned by generation
+# TODO: Read data for a specific generation from the partitioned files

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/README.md
@@ -1,0 +1,2 @@
+# gym_leader_etl_pipeline
+Gym battles generate lots of data that needs to be normalized. This folder outlines an ETL flow for extracting battle CSVs, transforming them to a common schema, and loading them into a gym_battles table. With standardized data we can track leader performance and trainer success rates. The pipeline illustrates typical steps of cleaning, type conversion, and loading into a relational store.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/example.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+# TODO: Extract battle records from CSV
+# TODO: Transform data to standardized schema
+# TODO: Load transformed data into gym_battles table (CSV or SQLite)

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/README.md
@@ -1,0 +1,2 @@
+# legendary_feature_store
+Legendary Pokémon possess unique qualities that make them prized for research and battle. This folder sketches a feature store capturing stats like base power, abilities, and generation for these rare creatures. Storing features centrally allows machine learning models to retrieve consistent, versioned data. The example outlines extracting features and registering them for later ML workflows.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Extract legendary Pokémon features
+# TODO: Register features in a central store and retrieve them for ML

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/README.md
@@ -1,0 +1,2 @@
+# pokedex_star_schema
+The Pokédex contains detailed records of every Pokémon encounter. This subproject models those encounters in a star schema to support analytics. The fact table stores each time a trainer sees or catches a Pokémon, while dimension tables describe Pokémon attributes, trainers, and locations. Joining these tables enables flexible queries about encounters and trainer behavior.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Build fact and dimension DataFrames for Pokédex encounters
+# TODO: Perform star schema join between fact table and dimensions

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/README.md
@@ -1,0 +1,2 @@
+# pokemon_data_lineage
+As Pokémon data is transformed through various pipelines, it helps to track where each dataset originates. This example attaches lineage metadata to DataFrame operations and produces a simple graph of transformations. Understanding lineage aids in debugging and compliance by showing how final results were derived. The stub will maintain basic links between input and output datasets.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Attach lineage metadata to DataFrame transformations
+# TODO: Output a simple graph representing dataset lineage

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/README.md
@@ -1,0 +1,2 @@
+# trade_cdc_simulation
+Pokémon trades happen frequently between trainers and can be tracked as a stream of change events. This project simulates capturing those events and applying them to a target dataset using Change Data Capture techniques. By processing insert and update events, we can maintain an up-to-date record of trades. The approach mirrors real-world CDC pipelines used for near real-time replication.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Read a stream of trade events in JSON
+# TODO: Apply inserts and updates to a target DataFrame to simulate CDC

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/README.md
@@ -1,0 +1,2 @@
+# trading_card_data_lake
+The Pokémon trading card game releases sets on a regular cadence and each set includes detailed card information. This directory demonstrates ingesting raw JSON card files into a date-partitioned data lake. Organizing by release date lets analysts quickly access cards from a specific set or timeframe. It also highlights how to organize semi-structured data for long-term storage.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/example.py
@@ -1,0 +1,5 @@
+import json
+from pathlib import Path
+
+# TODO: Write sample card JSON files into date-partitioned folders
+# TODO: Demonstrate reading JSON data for a given release date

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/README.md
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/README.md
@@ -1,0 +1,2 @@
+# type_effectiveness_materialized_view
+Type matchups determine the outcome of many battles in the Pokémon world. This module shows how to create a materialized view summarizing effectiveness relationships between types. By precomputing the results, queries about which types counter others run much faster. The example sets up base tables for types and effectiveness levels and demonstrates refreshing the view when data changes.

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/example.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+# TODO: Define tables for types and their effectiveness
+# TODO: Create and refresh a materialized view summarizing matchups


### PR DESCRIPTION
## Summary
- add pokemon directory to module 7 for DW & ADM
- include ten subfolders with README and example stubs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas, twilio)*

------
https://chatgpt.com/codex/tasks/task_e_68537afd5b0483278c1ecaca9cac5cfd