### PR TITLE
Implement Pokemon data warehousing samples

### DIFF
--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/battle_statistics_real_time/example.py
@@ -1,4 +1,36 @@
-import time
+"""Simple simulation of real-time battle log ingestion."""
 
-# TODO: Simulate real-time ingestion of battle logs
-# TODO: Append incoming records to a table or DataFrame
+import time
+from typing import Dict, List
+
+
+def ingest_battles(max_events: int = 5, delay: float = 0.1) -> List[Dict[str, str]]:
+    """Simulate streaming battle records.
+
+    Each event is appended to an in-memory list representing the target table.
+
+    Parameters
+    ----------
+    max_events:
+        How many battle events to generate.
+    delay:
+        Time to wait between events to mimic streaming.
+    """
+
+    logs: List[Dict[str, str]] = []
+    for i in range(max_events):
+        event = {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "attacker": f"Pokemon_{i % 3}",
+            "defender": f"Pokemon_{(i + 1) % 3}",
+            "winner": "attacker" if i % 2 == 0 else "defender",
+        }
+        logs.append(event)
+        time.sleep(delay)
+    return logs
+
+
+if __name__ == "__main__":
+    battle_logs = ingest_battles()
+    for log in battle_logs:
+        print(log)

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/cloud_vs_onprem_pokedex/example.py
@@ -1,5 +1,46 @@
-# Placeholder imports for database connections
-import sqlalchemy
+"""Compare querying a cloud vs on-prem Pokédex warehouse."""
 
-# TODO: Outline connections to AWS Redshift and local PostgreSQL
-# TODO: Run the same query against each warehouse and compare results
+import sqlite3
+from typing import List, Tuple
+
+
+def setup_db(conn: sqlite3.Connection) -> None:
+    """Create a simple Pokédex table and insert a few rows."""
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS pokedex (id INTEGER PRIMARY KEY, name TEXT)"
+    )
+    if not conn.execute("SELECT 1 FROM pokedex").fetchone():
+        conn.executemany(
+            "INSERT INTO pokedex (name) VALUES (?)",
+            [("Bulbasaur",), ("Charmander",), ("Squirtle",)],
+        )
+        conn.commit()
+
+
+def run_query(conn: sqlite3.Connection, query: str) -> List[Tuple[int, str]]:
+    """Execute a query and return all rows."""
+
+    cur = conn.cursor()
+    cur.execute(query)
+    return cur.fetchall()
+
+
+def main() -> None:
+    # Simulated cloud and on-prem databases using SQLite in-memory databases
+    cloud_conn = sqlite3.connect(":memory:")
+    onprem_conn = sqlite3.connect(":memory:")
+
+    for conn in (cloud_conn, onprem_conn):
+        setup_db(conn)
+
+    query = "SELECT * FROM pokedex"
+    cloud_results = run_query(cloud_conn, query)
+    onprem_results = run_query(onprem_conn, query)
+
+    print("Cloud results:", cloud_results)
+    print("On-prem results:", onprem_results)
+
+
+if __name__ == "__main__":
+    main()

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/generation_partitioned_table/example.py
@@ -1,4 +1,50 @@
-import pandas as pd
+"""Store Pokémon data partitioned by generation using CSV files."""
 
-# TODO: Write Pokémon data to Parquet partitioned by generation
-# TODO: Read data for a specific generation from the partitioned files
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+
+POKEMON = [
+    {"id": 1, "name": "Bulbasaur", "generation": 1},
+    {"id": 4, "name": "Charmander", "generation": 1},
+    {"id": 152, "name": "Chikorita", "generation": 2},
+    {"id": 255, "name": "Torchic", "generation": 3},
+]
+
+
+def write_partitioned(base: Path) -> None:
+    """Write sample data into generation-specific folders."""
+
+    for row in POKEMON:
+        folder = base / f"generation_{row['generation']}"
+        folder.mkdir(parents=True, exist_ok=True)
+        file = folder / "pokemon.csv"
+        write_header = not file.exists()
+        with open(file, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["id", "name", "generation"])
+            if write_header:
+                writer.writeheader()
+            writer.writerow(row)
+
+
+def read_generation(base: Path, generation: int) -> List[Dict[str, str]]:
+    """Load Pokémon rows for the given generation."""
+
+    file = base / f"generation_{generation}" / "pokemon.csv"
+    if not file.exists():
+        return []
+    with open(file, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def main() -> None:
+    base = Path("pokemon_by_generation")
+    write_partitioned(base)
+    gen1 = read_generation(base, 1)
+    print("Generation 1:", gen1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/gym_leader_etl_pipeline/example.py
@@ -1,5 +1,80 @@
-import pandas as pd
+"""Example ETL pipeline for gym leader battle records."""
 
-# TODO: Extract battle records from CSV
-# TODO: Transform data to standardized schema
-# TODO: Load transformed data into gym_battles table (CSV or SQLite)
+import csv
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+def extract(csv_file: Path) -> List[Dict[str, str]]:
+    """Read battle records from a CSV file."""
+
+    with open(csv_file, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def transform(records: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Normalize raw records to a common schema."""
+
+    transformed = []
+    for row in records:
+        transformed.append(
+            {
+                "gym": row["gym"].title(),
+                "leader": row["leader"].title(),
+                "pokemon": row["pokemon"].title(),
+                "result": row["result"].lower(),
+            }
+        )
+    return transformed
+
+
+def load(db_path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    """Load rows into a SQLite table."""
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS gym_battles (gym TEXT, leader TEXT, pokemon TEXT, result TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO gym_battles VALUES (:gym, :leader, :pokemon, :result)", rows
+    )
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    sample_csv = Path("battles.csv")
+    # Create a small sample CSV if one does not exist
+    if not sample_csv.exists():
+        with open(sample_csv, "w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["gym", "leader", "pokemon", "result"]
+            )
+            writer.writeheader()
+            writer.writerows(
+                [
+                    {
+                        "gym": "Pewter",
+                        "leader": "Brock",
+                        "pokemon": "Onix",
+                        "result": "WIN",
+                    },
+                    {
+                        "gym": "Cerulean",
+                        "leader": "Misty",
+                        "pokemon": "Staryu",
+                        "result": "LOSS",
+                    },
+                ]
+            )
+
+    raw = extract(sample_csv)
+    rows = transform(raw)
+    load(Path("gym_battles.db"), rows)
+    print(f"Loaded {len(rows)} battle records")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/legendary_feature_store/example.py
@@ -1,4 +1,47 @@
-import pandas as pd
+"""Demonstrate a tiny feature store for legendary Pokémon."""
 
-# TODO: Extract legendary Pokémon features
-# TODO: Register features in a central store and retrieve them for ML
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+LEGENDARIES = [
+    {"name": "Mewtwo", "base_power": 680, "generation": 1},
+    {"name": "Lugia", "base_power": 680, "generation": 2},
+]
+
+
+def register_features(store: Path, features: Iterable[Dict[str, object]]) -> None:
+    """Append feature dictionaries to a JSON file."""
+
+    store.parent.mkdir(exist_ok=True)
+    data: List[Dict[str, object]] = []
+    if store.exists():
+        with open(store) as f:
+            data = json.load(f)
+    data.extend(features)
+    with open(store, "w") as f:
+        json.dump(data, f)
+
+
+def load_features(store: Path) -> List[Dict[str, object]]:
+    """Retrieve all registered features."""
+
+    if not store.exists():
+        return []
+    with open(store) as f:
+        return json.load(f)
+
+
+def main() -> None:
+    store = Path("legendary_features.json")
+    register_features(store, LEGENDARIES)
+    all_features = load_features(store)
+    print("Registered features:")
+    for feat in all_features:
+        print(feat)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokedex_star_schema/example.py
@@ -1,4 +1,43 @@
-import pandas as pd
+"""Star schema demonstration for Pokédex encounters."""
 
-# TODO: Build fact and dimension DataFrames for Pokédex encounters
-# TODO: Perform star schema join between fact table and dimensions
+from typing import Dict, List
+
+
+POKEMON_DIM = {
+    1: {"pokemon_name": "Bulbasaur", "type": "grass"},
+    4: {"pokemon_name": "Charmander", "type": "fire"},
+}
+
+TRAINER_DIM = {10: {"trainer_name": "Ash"}, 20: {"trainer_name": "Misty"}}
+
+FACT_TABLE = [
+    {"encounter_id": 100, "trainer_id": 10, "pokemon_id": 1, "location": "Pallet"},
+    {"encounter_id": 101, "trainer_id": 20, "pokemon_id": 4, "location": "Cerulean"},
+]
+
+
+def star_join() -> List[Dict[str, str]]:
+    """Join fact rows with dimension lookups."""
+
+    results: List[Dict[str, str]] = []
+    for row in FACT_TABLE:
+        pokemon = POKEMON_DIM[row["pokemon_id"]]
+        trainer = TRAINER_DIM[row["trainer_id"]]
+        joined = {
+            **row,
+            **pokemon,
+            **trainer,
+        }
+        results.append(joined)
+    return results
+
+
+def main() -> None:
+    rows = star_join()
+    for r in rows:
+        print(r)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/pokemon_data_lineage/example.py
@@ -1,4 +1,39 @@
-import pandas as pd
+"""Track simple dataset lineage for Pokémon transformations."""
 
-# TODO: Attach lineage metadata to DataFrame transformations
-# TODO: Output a simple graph representing dataset lineage
+from typing import Any, Dict, List
+
+
+class Dataset:
+    def __init__(self, data: List[Dict[str, Any]], lineage: List[str] | None = None):
+        self.data = data
+        self.lineage = lineage or []
+
+    def filter_fire(self) -> "Dataset":
+        filtered = [row for row in self.data if row["type"] == "fire"]
+        return Dataset(filtered, self.lineage + ["Filtered fire type"])
+
+    def add_power_score(self) -> "Dataset":
+        scored = [dict(row, power=row["base"] * 2) for row in self.data]
+        return Dataset(scored, self.lineage + ["Added power score"])
+
+
+def display_lineage(ds: Dataset) -> None:
+    print("Lineage:")
+    for i, step in enumerate(ds.lineage, 1):
+        print(f"{i}. {step}")
+
+
+def main() -> None:
+    raw = Dataset([
+        {"name": "Charmander", "type": "fire", "base": 39},
+        {"name": "Squirtle", "type": "water", "base": 44},
+    ], ["Loaded raw data"])
+
+    fire_only = raw.filter_fire()
+    scored = fire_only.add_power_score()
+    display_lineage(scored)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trade_cdc_simulation/example.py
@@ -1,4 +1,44 @@
-import pandas as pd
+"""Simulate Change Data Capture for Pokémon trades."""
 
-# TODO: Read a stream of trade events in JSON
-# TODO: Apply inserts and updates to a target DataFrame to simulate CDC
+from typing import Dict, List
+
+
+def apply_event(target: Dict[int, Dict[str, str]], event: Dict[str, str]) -> None:
+    """Apply an insert or update event to the target table."""
+
+    trade_id = int(event["trade_id"])
+    op = event.get("op")
+    if op == "insert" or trade_id not in target:
+        target[trade_id] = event
+    elif op == "update":
+        target[trade_id].update(event)
+
+
+def main() -> None:
+    events: List[Dict[str, str]] = [
+        {
+            "trade_id": 1,
+            "op": "insert",
+            "trainer_a": "Ash",
+            "trainer_b": "Misty",
+            "pokemon": "Staryu",
+        },
+        {
+            "trade_id": 1,
+            "op": "update",
+            "pokemon": "Psyduck",
+        },
+    ]
+
+    target: Dict[int, Dict[str, str]] = {}
+    for e in events:
+        apply_event(target, e)
+
+    print("Current trades:")
+    for trade in target.values():
+        print(trade)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/trading_card_data_lake/example.py
@@ -1,5 +1,44 @@
+"""Organize trading card data in a date-partitioned lake."""
+
 import json
 from pathlib import Path
+from typing import List, Dict
 
-# TODO: Write sample card JSON files into date-partitioned folders
-# TODO: Demonstrate reading JSON data for a given release date
+
+CARDS = [
+    {"id": 1, "name": "Pikachu", "release": "2023-01-01"},
+    {"id": 2, "name": "Bulbasaur", "release": "2023-01-02"},
+]
+
+
+def write_cards(base: Path) -> None:
+    """Write card JSON files partitioned by release date."""
+
+    for card in CARDS:
+        folder = base / card["release"]
+        folder.mkdir(parents=True, exist_ok=True)
+        with open(folder / f"{card['id']}.json", "w") as f:
+            json.dump(card, f)
+
+
+def read_release(base: Path, release: str) -> List[Dict[str, object]]:
+    """Read all cards for a given release date."""
+
+    folder = base / release
+    cards: List[Dict[str, object]] = []
+    for file in folder.glob("*.json"):
+        with open(file) as f:
+            cards.append(json.load(f))
+    return cards
+
+
+def main() -> None:
+    lake = Path("card_lake")
+    write_cards(lake)
+    jan1_cards = read_release(lake, "2023-01-01")
+    print("Cards released on 2023-01-01:", jan1_cards)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/example.py
+++ b/Data Warehousing and Advanced Data Management/module 7/pokemon/type_effectiveness_materialized_view/example.py
@@ -1,4 +1,38 @@
-import pandas as pd
+"""Materialized view summarizing Pokémon type effectiveness."""
 
-# TODO: Define tables for types and their effectiveness
-# TODO: Create and refresh a materialized view summarizing matchups
+from typing import Dict, Tuple, Set
+
+
+TYPE_MATCHUPS = [
+    ("fire", "grass", "super"),
+    ("water", "fire", "super"),
+    ("grass", "water", "super"),
+    ("fire", "water", "weak"),
+]
+
+
+def create_materialized_view(data: list[Tuple[str, str, str]]) -> Set[Tuple[str, str, str]]:
+    """Build the materialized view as a set of matchups."""
+
+    return set(data)
+
+
+def refresh_view(view: Set[Tuple[str, str, str]], data: list[Tuple[str, str, str]]) -> Set[Tuple[str, str, str]]:
+    """Refresh the view when base data changes."""
+
+    return create_materialized_view(data)
+
+
+def main() -> None:
+    view = create_materialized_view(TYPE_MATCHUPS)
+    print("Initial view:", view)
+
+    # Add a new relationship and refresh
+    TYPE_MATCHUPS.append(("electric", "water", "super"))
+    view = refresh_view(view, TYPE_MATCHUPS)
+    print("Refreshed view:", view)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- flesh out all example modules under `module 7/pokemon`
- add simple implementations for battle ingestion, database comparisons, ETL pipelines and more

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', ModuleNotFoundError: No module named 'twilio')*

------
https://chatgpt.com/codex/tasks/task_e_68537c53e6088327a5af3479aaef4934